### PR TITLE
fix #55: SaaS 获取用户 API 调整，修复搜索 API 异常等

### DIFF
--- a/src/api/bkuser_core/common/viewset.py
+++ b/src/api/bkuser_core/common/viewset.py
@@ -184,8 +184,7 @@ class AdvancedSearchFilter(filters.SearchFilter, DynamicFieldsMixin):
 
         if wildcard_search and wildcard_search_fields:
             target_lookups = [Q(**{"{}__icontains".format(x): wildcard_search}) for x in wildcard_search_fields]
-            # 如果选择了 wildcard 搜索，则忽略其他搜索条件
-            return queryset.filter(functools.reduce(or_, target_lookups))
+            queryset = queryset.filter(functools.reduce(or_, target_lookups))
 
         # 2. 单字段搜索
         return self.make_lookups(query_data, queryset, search_field)

--- a/src/saas/bkuser_shell/organization/serializers/profiles.py
+++ b/src/saas/bkuser_shell/organization/serializers/profiles.py
@@ -9,15 +9,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 from bkuser_shell.organization.utils import get_default_logo_url
-from rest_framework.serializers import (
-    BooleanField,
-    CharField,
-    IntegerField,
-    JSONField,
-    ListField,
-    Serializer,
-    SerializerMethodField,
-)
+from rest_framework.serializers import CharField, IntegerField, JSONField, ListField, Serializer, SerializerMethodField
 
 from .departments import SubDepartmentSerializer
 
@@ -39,7 +31,7 @@ class ProfileSerializer(Serializer):
     password = CharField(required=False)
     position = IntegerField(required=False)
     role = IntegerField(required=False)
-    email = CharField()
+    email = CharField(required=False)
     username = CharField(required=True)
     display_name = CharField(required=True)
     leader = ListField(required=False, default=[], child=LeaderSerializer())
@@ -70,6 +62,11 @@ class ProfileSerializer(Serializer):
         return data.iso_code
 
 
+class ProfileResultSerializer(Serializer):
+    count = IntegerField()
+    data = ProfileSerializer(many=True, source="results")
+
+
 class LoginInfoSerializer(Serializer):
     username = CharField()
     logo = SerializerMethodField(required=False)
@@ -90,9 +87,7 @@ class LoginInfoSerializer(Serializer):
 
 
 class ListProfilesSerializer(Serializer):
-    no_page = BooleanField(default=False)
-    username = CharField(required=False)
-    display_name = CharField(required=False)
+    keyword = CharField(required=False)
     page = IntegerField(required=False, default=1)
     page_size = IntegerField(required=False, default=10)
 

--- a/src/saas/bkuser_shell/organization/views/misc.py
+++ b/src/saas/bkuser_shell/organization/views/misc.py
@@ -58,7 +58,7 @@ class SearchViewSet(BkUserApiViewSet):
         _cached_categories_map = {x["id"]: x["display_name"] for x in categories}
 
         # 2. 获取动态字段信息
-        fields = fields_api_instance.v2_dynamic_fields_list()
+        fields = fields_api_instance.v2_dynamic_fields_list()["results"]
         extra_fields = [x for x in fields if not x["builtin"]]
 
         # 分页，保证搜索速度


### PR DESCRIPTION
- 调整 SaaS 获取用户 API `categories/${id}/profiles/` 逻辑，去除全量参数，支持参数搜索
- 修复搜索 API 异常（后端去除全量导致）
- API 部分调整，支持 `wildcard` 和 `lookup` 搜索同时工作

Fixes #55 