### PR TITLE
fix(deploy/helm): fix /ping always redirect to /ping/ in kube-probe

### DIFF
--- a/deploy/helm/bk-user/charts/api/templates/web-deployment.yaml
+++ b/deploy/helm/bk-user/charts/api/templates/web-deployment.yaml
@@ -66,11 +66,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /ping
+              path: /ping/
               port: http
           readinessProbe:
             httpGet:
-              path: /ping
+              path: /ping/
               port: http
           resources:
             {{- toYaml .Values.resources.web | nindent 12 }}


### PR DESCRIPTION
```
[25/Feb/2022:14:30:32 +0800] "GET /ping HTTP/1.1" 301 1772 0 "-" "kube-probe/1.21"
[25/Feb/2022:14:30:32 +0800] "GET /ping HTTP/1.1" 301 1772 0 "-" "kube-probe/1.21"
[25/Feb/2022:14:30:32 +0800] "GET /ping/ HTTP/1.1" 200 1954 4 "http://10.244.0.5:8000/ping" "kube-probe/1.21"
[25/Feb/2022:14:30:32 +0800] "GET /ping/ HTTP/1.1" 200 2666 4 "http://10.244.0.5:8000/ping" "kube-probe/1.21"
```