### PR TITLE
fix(api/ldap): test_connection use data in db, should use the data from form

### DIFF
--- a/src/api/bkuser_core/categories/plugins/base.py
+++ b/src/api/bkuser_core/categories/plugins/base.py
@@ -214,6 +214,9 @@ class Syncer:
 
     context: SyncContext = field(default_factory=SyncContext)
 
+    # 决定是否初始化client, 默认为True, 即默认会初始化; 某些场景不需要初始化(例如test_connection), 需要设置为False
+    with_initialize_client: bool = True
+
     def __post_init__(self):
         try:
             self.category = ProfileCategory.objects.get(pk=self.category_id)
@@ -228,7 +231,7 @@ class Syncer:
         raise NotImplementedError
 
     def get_fetcher(self):
-        return self.fetcher_cls(self.category_id, self.config_loader)
+        return self.fetcher_cls(self.category_id, self.config_loader, self.with_initialize_client)
 
     def disable_departments_before_sync(self, exempt_ids: list = None):
         """全同步前禁用该目录下的组织

--- a/src/api/bkuser_core/categories/plugins/ldap/client.py
+++ b/src/api/bkuser_core/categories/plugins/ldap/client.py
@@ -29,14 +29,17 @@ logger = logging.getLogger(__name__)
 class LDAPClient:
     config_provider: "ConfigProvider"
 
+    with_initialize_client: bool = True
+
     def __post_init__(self):
-        self.con = self.initialize(
-            connection_url=self.config_provider.get("connection_url"),
-            user=self.config_provider.get("user"),
-            password=self.config_provider.get("password"),
-            timeout_setting=self.config_provider.get("timeout_setting", 120),
-            use_ssl=bool(self.config_provider.get("ssl_encryption") == "SSL"),
-        )
+        if self.with_initialize_client:
+            self.con = self.initialize(
+                connection_url=self.config_provider.get("connection_url"),
+                user=self.config_provider.get("user"),
+                password=self.config_provider.get("password"),
+                timeout_setting=self.config_provider.get("timeout_setting", 120),
+                use_ssl=bool(self.config_provider.get("ssl_encryption") == "SSL"),
+            )
 
         self.start_root = self.config_provider.get("basic_pull_node")
 

--- a/src/api/bkuser_core/categories/plugins/ldap/syncer.py
+++ b/src/api/bkuser_core/categories/plugins/ldap/syncer.py
@@ -37,8 +37,11 @@ class LDAPFetcher(Fetcher):
 
     DN_REGEX = re.compile("(?P<key>[ \\w-]+)=(?P<value>[ \\w-]+)")
 
+    # 决定是否初始化client, 默认为True, 即默认会初始化; 某些场景不需要初始化(例如test_connection), 需要设置为False
+    with_initialize_client: bool = True
+
     def __post_init__(self):
-        self.client = LDAPClient(self.config_loader)
+        self.client = LDAPClient(self.config_loader, self.with_initialize_client)
         self.field_mapper = ProfileFieldMapper(config_loader=self.config_loader)
         self._data: Tuple[List, List, List] = None
 

--- a/src/api/bkuser_core/categories/views.py
+++ b/src/api/bkuser_core/categories/views.py
@@ -195,7 +195,9 @@ class CategoryViewSet(AdvancedModelViewSet, AdvancedListAPIView):
             raise error_codes.LOAD_LDAP_CLIENT_FAILED
 
         try:
-            syncer_cls(instance.id).fetcher.client.initialize(**serializer.validated_data)
+            syncer_cls(instance.id, with_initialize_client=False).fetcher.client.initialize(
+                **serializer.validated_data
+            )
         except Exception:
             logger.exception("failed to test initialize category<%s>", instance.id)
             raise error_codes.TEST_CONNECTION_FAILED


### PR DESCRIPTION
close #447

-----

`syncer_cls(instance.id).fetcher.client.initialize(**serializer.validated_data)`

原因: `__post_init__`优先于`initialize`执行


FIXME: 执行test_connection的时候, 实际上在这里就执行`__post_init__`了, 使用的是db中存储的, 而不是用户表单传入的! 异常在这里就被抛出了