### PR TITLE
fix(ldap/create): create mad dir fail while update_or_create_sync_tasks

### DIFF
--- a/src/api/bkuser_core/api/web/category/views.py
+++ b/src/api/bkuser_core/api/web/category/views.py
@@ -142,11 +142,11 @@ class CategorySettingNamespaceListCreateUpdateApi(
             try:
                 # 暂时忽略已创建报错
                 setting, created = Setting.objects.update_or_create(
-                    meta=meta, value=setting["value"], category=category
+                    meta=meta, category=category, defaults={"value": setting["value"]}
                 )
             except Exception:
                 logger.exception(
-                    "cannot create setting. [meta=%s, value=%s, category=%s]", metas[0], setting["value"], category
+                    "cannot create setting. [meta=%s, value=%s, category=%s]", meta, setting["value"], category
                 )
                 raise error_codes.CANNOT_CREATE_SETTING
             else:

--- a/src/api/bkuser_core/categories/plugins/ldap/handlers.py
+++ b/src/api/bkuser_core/categories/plugins/ldap/handlers.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 PULL_INTERVAL_SETTING_KEY = "pull_cycle"
 
+DEFAULT_MIN_SYNC_PERIOD = 60
+
 
 def update_or_create_sync_tasks(instance: "Setting", operator: str):
     """尝试创建或更新同步数据任务"""
@@ -42,7 +44,7 @@ def update_or_create_sync_tasks(instance: "Setting", operator: str):
     cycle_value = int(instance.value)
     config_provider = ConfigProvider(instance.category_id)
 
-    min_sync_period = config_provider.get("min_sync_period")
+    min_sync_period = config_provider.get("min_sync_period", DEFAULT_MIN_SYNC_PERIOD)
     if cycle_value <= 0:
         # 特殊约定，当设置 <= 0 时，删除周期任务
         delete_periodic_sync_task(category_id=instance.category_id)


### PR DESCRIPTION
#777

原因: 首次创建目录的时候, 目录配置还没被初始化, 此时config_provider是拿不到任何东西的; 默认是None

