### PR TITLE
fix: 目录meta list接口rsa设置不返回

### DIFF
--- a/src/api/bkuser_core/api/web/constants.py
+++ b/src/api/bkuser_core/api/web/constants.py
@@ -10,3 +10,9 @@ specific language governing permissions and limitations under the License.
 """
 
 EXCLUDE_SETTINGS_META_KEYS = ["password_rsa_private_key"]
+
+EXCLUDE_SETTINGS_META_IN_META_LISTVIEW = [
+    "enable_password_rsa_encrypted",
+    "password_rsa_public_key",
+    "password_rsa_private_key",
+]

--- a/src/api/bkuser_core/api/web/setting/views.py
+++ b/src/api/bkuser_core/api/web/setting/views.py
@@ -12,9 +12,10 @@ specific language governing permissions and limitations under the License.
 from rest_framework import generics
 
 from .serializers import SettingMetaOutputSLZ, SettingMetasListInputSLZ
-from bkuser_core.user_settings.models import SettingMeta
 
 # from bkuser_core.bkiam.permissions import ManageFieldPermission
+from bkuser_core.api.web.constants import EXCLUDE_SETTINGS_META_IN_META_LISTVIEW
+from bkuser_core.user_settings.models import SettingMeta
 
 
 class SettingMetasListApi(generics.ListAPIView):
@@ -31,7 +32,9 @@ class SettingMetasListApi(generics.ListAPIView):
         category_type = data["category_type"]
         namespace = data["namespace"]
 
-        queryset = SettingMeta.objects.filter(category_type=category_type)
+        queryset = SettingMeta.objects.filter(category_type=category_type).exclude(
+            key__in=EXCLUDE_SETTINGS_META_IN_META_LISTVIEW
+        )
         if namespace:
             queryset = queryset.filter(namespace=namespace)
         return queryset


### PR DESCRIPTION
meta接口发挥rsa的meta数据；创建目录时，生成rsa的默认配置，导致后续校验失败