### PR TITLE
fix: auth tenant user not match `id` field

### DIFF
--- a/src/bk-user/bkuser/biz/idp.py
+++ b/src/bk-user/bkuser/biz/idp.py
@@ -27,7 +27,11 @@ class AuthenticationMatcher:
     def __init__(self, tenant_id: str, idp_id: str):
         # TODO: 后续支持协同租户的数据源用户匹配
         self.idp = Idp.objects.get(id=idp_id, owner_tenant_id=tenant_id)
+        # 内置字段
         self.builtin_field_data_type_map = dict(UserBuiltinField.objects.all().values_list("name", "data_type"))
+        # Note: Local登录允许匹配ID
+        self.builtin_field_data_type_map["id"] = UserFieldDataType.NUMBER
+        # 自定义字段
         self.custom_field_data_type_map = dict(
             TenantUserCustomField.objects.filter(tenant_id=tenant_id).values_list("name", "data_type")
         )

--- a/src/bk-user/tests/biz/test_idp.py
+++ b/src/bk-user/tests/biz/test_idp.py
@@ -28,6 +28,7 @@ class TestAuthenticationMatcher:
     @pytest.mark.parametrize(
         ("field", "excepted_filter_key"),
         [
+            ("id", "id"),
             ("username", "username"),
             ("full_name", "full_name"),
             ("phone_country_code", "phone_country_code"),
@@ -107,10 +108,25 @@ class TestAuthenticationMatcher:
                     & Q(extras__region="111@qq.com")
                 ),
             ),
+            # ID Field Compare rule
+            (
+                DataSourceMatchRule(
+                    data_source_id=1,
+                    field_compare_rules=[FieldCompareRule(source_field="id", target_field="id")],
+                ),
+                (Q(data_source_id=1) & Q(id=100)),
+            ),
+            (
+                DataSourceMatchRule(
+                    data_source_id=1,
+                    field_compare_rules=[FieldCompareRule(source_field="user_id", target_field="id")],
+                ),
+                (Q(data_source_id=1) & Q(id="test_username")),
+            ),
         ],
     )
     def test_convert_one_rule_to_queryset_filter_for_rule(self, rule, excepted_queryset):
-        source_data = {"user_id": "test_username", "phone": "1234567890123", "email": "111@qq.com"}
+        source_data = {"id": 100, "user_id": "test_username", "phone": "1234567890123", "email": "111@qq.com"}
 
         queryset = self.matcher._convert_one_rule_to_queryset_filter(rule, source_data)
 


### PR DESCRIPTION
- 修复认证时无法匹配ID字段
