### PR TITLE
Fix 2.5.3 bug

### DIFF
--- a/src/api/bkuser_core/api/login/views.py
+++ b/src/api/bkuser_core/api/login/views.py
@@ -31,8 +31,8 @@ from bkuser_core.api.login.serializers import (
     ProfileLoginSerializer,
     ProfileSerializer,
 )
-from bkuser_core.audit.constants import LogInFailReason
-from bkuser_core.audit.utils import create_profile_log
+from bkuser_core.audit.constants import LogInFailReason, OperationType
+from bkuser_core.audit.utils import create_general_log, create_profile_log
 from bkuser_core.categories.constants import CategoryType
 from bkuser_core.categories.loader import get_plugin_by_category
 from bkuser_core.categories.models import ProfileCategory
@@ -333,6 +333,13 @@ class ProfileLoginViewSet(viewsets.ViewSet):
             except Exception:  # pylint: disable=broad-except
                 logger.exception("failed to update iso_code for profile %s", username)
                 # do nothing
+
+        create_general_log(
+            operator=request.operator,
+            operate_type=OperationType.CREATE.value if created else OperationType.UPDATE.value,
+            operator_obj=profile,
+            request=request,
+        )
 
         return Response(data=ProfileSerializer(profile, context={"request": request}).data)
 

--- a/src/api/bkuser_core/api/web/export.py
+++ b/src/api/bkuser_core/api/web/export.py
@@ -154,9 +154,7 @@ class ProfileExcelExporter:
         """更新表格标题"""
         required_fields = [x for x in self.fields if x["builtin"] and x["name"] not in exclude_keys]
         not_required_field_names = [
-            x["display_name"]
-            for x in self.fields
-            if not x["builtin"] and x["name"] not in exclude_keys
+            x["display_name"] for x in self.fields if not x["builtin"] and x["name"] not in exclude_keys
         ]
 
         field_col_map = {}

--- a/src/api/bkuser_core/api/web/profile/views.py
+++ b/src/api/bkuser_core/api/web/profile/views.py
@@ -37,6 +37,7 @@ from bkuser_core.bkiam.permissions import IAMAction, ManageDepartmentProfilePerm
 from bkuser_core.categories.models import ProfileCategory
 from bkuser_core.common.error_codes import error_codes
 from bkuser_core.departments.models import Department
+from bkuser_core.profiles.constants import ProfileStatus
 from bkuser_core.profiles.exceptions import CountryISOCodeNotMatch
 from bkuser_core.profiles.models import DynamicFieldInfo, Profile
 from bkuser_core.profiles.signals import post_profile_create, post_profile_update
@@ -47,7 +48,6 @@ from bkuser_core.profiles.utils import (
     parse_username_domain,
     should_check_old_password,
 )
-from bkuser_core.profiles.constants import ProfileStatus
 from bkuser_core.user_settings.constants import SettingsEnableNamespaces
 from bkuser_core.user_settings.models import Setting, SettingMeta
 

--- a/src/api/bkuser_core/categories/plugins/local/syncer.py
+++ b/src/api/bkuser_core/categories/plugins/local/syncer.py
@@ -26,6 +26,7 @@ from .parsers import (
     ColumnParser,
     DepartmentCellParser,
     DepartmentColumnParser,
+    EmailCellParser,
     LeadersCellParser,
     PhoneNumberParser,
     UsernameCellParser,
@@ -425,6 +426,7 @@ class ParserSet:
             DepartmentCellParser,
             LeadersCellParser,
             PhoneNumberParser,
+            EmailCellParser,
         ]:
             l_parsers[cell_cls.name] = cell_cls.__call__(category_id)
 

--- a/src/api/bkuser_core/common/middlewares.py
+++ b/src/api/bkuser_core/common/middlewares.py
@@ -32,6 +32,7 @@ class BKLanguageMiddleware(MiddlewareMixin):
     这里通过使用Blueking-Language值替换Accept-Language的值来达到设置语言的目的
     Note: BKLanguageMiddleware 必须配置在django.middleware.locale.LocaleMiddleware之前
     """
+
     BK_LANGUAGE_HEADER = "HTTP_BLUEKING_LANGUAGE"
     LANGUAGE_HEADER = "HTTP_ACCEPT_LANGUAGE"
 

--- a/src/api/bkuser_core/profiles/v2/serializers.py
+++ b/src/api/bkuser_core/profiles/v2/serializers.py
@@ -16,8 +16,8 @@ from rest_framework import serializers
 from bkuser_core.apis.v2.serializers import AdvancedRetrieveSerializer, CustomFieldsMixin, CustomFieldsModelSerializer
 from bkuser_core.departments.v2.serializers import ForSyncDepartmentSerializer, SimpleDepartmentSerializer
 from bkuser_core.profiles.cache import get_extras_default_from_local_cache
-from bkuser_core.profiles.models import DynamicFieldInfo, Profile
 from bkuser_core.profiles.constants import LanguageEnum
+from bkuser_core.profiles.models import DynamicFieldInfo, Profile
 from bkuser_core.profiles.utils import get_username, parse_username_domain, remove_sensitive_fields_for_profile
 from bkuser_core.profiles.validators import validate_domain, validate_username
 

--- a/src/api/bkuser_core/tests/categories/plugins/local/test_parsers.py
+++ b/src/api/bkuser_core/tests/categories/plugins/local/test_parsers.py
@@ -18,6 +18,7 @@ from bkuser_core.categories.plugins.local.parsers import (
     ColumnParser,
     DepartmentCellParser,
     DepartmentColumnParser,
+    EmailCellParser,
     LeadersCellParser,
     PhoneNumberParser,
     UsernameCellParser,
@@ -125,13 +126,46 @@ class TestPhoneNumberParser:
             PhoneNumberParser(1).parse("")
 
     @pytest.mark.parametrize(
-        "case, expected",
+        "case",
         [
-            ("+", {"telephone": "+"}),
+            "+",
+            "12345",
+            "1300000000012",
         ],
     )
-    def test_parse_exception(self, case, expected):
-        assert PhoneNumberParser(1).parse(case) == expected
+    def test_parse_exception(self, case):
+        with pytest.raises(ParseFailedException):
+            PhoneNumberParser(1).parse(case)
+
+
+class TestEmailParser:
+    @pytest.mark.parametrize(
+        "case, expected",
+        [
+            ("abc@xyz.com", ({"email": "abc@xyz.com"})),
+            ("123@xyz.com", ({"email": "123@xyz.com"})),
+            ("test@example.net", ({"email": "test@example.net"})),
+        ],
+    )
+    def test_normal_email(self, case, expected):
+        r = EmailCellParser(1).parse(case)
+        assert expected == r
+
+    def test_parse_empty(self):
+        with pytest.raises(ParseFailedException):
+            EmailCellParser(1).parse("")
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            "123@",
+            "123",
+            "123.com",
+        ],
+    )
+    def test_parse_exception(self, case):
+        with pytest.raises(ParseFailedException):
+            EmailCellParser(1).parse(case)
 
 
 class TestLeadersCellParser:

--- a/src/api/bkuser_core/tests/categories/plugins/local/test_syncer.py
+++ b/src/api/bkuser_core/tests/categories/plugins/local/test_syncer.py
@@ -62,8 +62,8 @@ class TestExcelSyncer:
             (
                 ["A", "B", "C"],
                 [
-                    [*["aaaa"] * 6, ""],
-                    [*["bbbb"] * 6, "A/B/C"],
+                    [*["aaaa"] * 2, "aaaa@test.com", "13000000000", *["aaaa"] * 2, ""],
+                    [*["bbbb"] * 2, "bbbb@test.com", "13000000001", *["bbbb"] * 2, "A/B/C"],
                 ],
                 COMMON_TITLES,
                 {"aaaa", "bbbb"},
@@ -71,9 +71,9 @@ class TestExcelSyncer:
             (
                 ["A", "B", "C"],
                 [
-                    [*["aaaa"] * 6, "", "ddd"],
-                    [*["bbbb"] * 6, "A/B/C", "qqq"],
-                    [*["cccc"] * 6, "A/B/C", ""],
+                    [*["aaaa"] * 2, "bbbb@test.com", "13000000000", *["aaaa"] * 2, "", "ddd"],
+                    [*["bbbb"] * 2, "bbbb@test.com", "13000000000", *["bbbb"] * 2, "A/B/C", "qqq"],
+                    [*["cccc"] * 2, "cccc@test.com", "13000000000", *["cccc"] * 2, "A/B/C", ""],
                 ],
                 [*COMMON_TITLES, "自定义字段1"],
                 {"aaaa", "bbbb", "cccc"},
@@ -109,8 +109,8 @@ class TestExcelSyncer:
         [
             (
                 [
-                    [*["aaaa"] * 2, "xxxx@xxxx.xyz", *["aaaa"] * 3, ""],
-                    [*["bbbb"] * 2, "xxxx@xxxx.xyz", *["bbbb"] * 3, ""],
+                    [*["aaaa"] * 2, "xxxx@xxxx.xyz", "13000000000", *["aaaa"] * 2, ""],
+                    [*["bbbb"] * 2, "xxxx@xxxx.xyz", "13000000000", *["bbbb"] * 2, ""],
                 ],
                 COMMON_TITLES,
                 {
@@ -140,8 +140,8 @@ class TestExcelSyncer:
         [
             (
                 [
-                    [*["aaaa"] * 6, "", ""],
-                    [*["bbbb"] * 6, "", "aaaa"],
+                    [*["aaaa"] * 2, "aaaa@test.com", "13000000000", *["aaaa"] * 2, "", ""],
+                    [*["bbbb"] * 2, "bbbb@test.com", "13000000000", *["bbbb"] * 2, "", "aaaa"],
                 ],
                 [*COMMON_TITLES, "上级"],
                 {"aaaa", "bbbb"},
@@ -187,7 +187,7 @@ class TestExcelSyncer:
         with pytest.raises(Exception) as exc_info:
             syncer._sync_users(make_parser_set(titles), users)
         assert (
-            "导入执行完成: 成功 1 条记录, 失败 2 条记录" in exc_info.value.args[0]
+            "导入执行完成: 成功 0 条记录, 失败 3 条记录" in exc_info.value.args[0]
             or "导入执行完成: 成功 0 条记录, 失败 1 条记录" in exc_info.value.args[0]
         )
 

--- a/src/api/bkuser_core/tests/categories/plugins/test_plugin.py
+++ b/src/api/bkuser_core/tests/categories/plugins/test_plugin.py
@@ -86,7 +86,7 @@ class TestPlugin:
         """test load settings"""
 
         for key, meta_info in settings.items():
-            plugin.init_settings(key, meta_info)
+            plugin.init_settings(key, meta_info, {test_category.id: True})
 
         assert (
             list(
@@ -106,14 +106,14 @@ class TestPlugin:
         update_time = meta.update_time
 
         time.sleep(0.1)
-        plugin.init_settings("foo", {"region": "a", "namespace": "b", "default": "wasd"})
+        plugin.init_settings("foo", {"region": "a", "namespace": "b", "default": "wasd"}, {test_category.id: True})
         new_update_time = SettingMeta.objects.get(category_type="test", key="foo", namespace="b").update_time
 
         assert update_time == new_update_time
 
         # region 可以被修改
         time.sleep(0.1)
-        plugin.init_settings("foo", {"region": "www", "namespace": "b"})
+        plugin.init_settings("foo", {"region": "www", "namespace": "b"}, {test_category.id: True})
         meta = SettingMeta.objects.get(category_type="test", key="foo", namespace="b")
         assert update_time != meta.update_time
         assert meta.region == "www"


### PR DESCRIPTION
### Description

Fixes 2.5.3 bug遗留
1. login.upsert接口缺少审计
2. 未配置mad和ldap类型的目录，过几分钟后刷新页面，【未完成】标识丢失
3. 本地目录用户excel导入，未对内置字段做校验
4. mad/ldap启用状态变更，周期同步任务状态未变更

