### PR TITLE
fix:组织架构 - 用户批量操作 部分操作仅本地数据源

### DIFF
--- a/src/pages/src/views/organization/components/table-list.vue
+++ b/src/pages/src/views/organization/components/table-list.vue
@@ -13,13 +13,7 @@
             </bk-button>
             <bk-button class="mr-[16px]" v-if="isShowBtn"
               @click="handleGetUsersDialog">{{ $t('拉取已有用户') }}</bk-button>
-            <batchOperation
-               :select-list="selectList"
-               :isEnabledPassword="isEnabledPassword"
-               :isEnabledMoveOrg="isEnabledMoveOrg"
-               :isEnabledDelPassword="isEnabledDelPassword"
-               :permittedUpdateItems="permittedUpdateItems"
-               @moveOrg="batchMoveOrg" @reloadList="reloadList"/>
+            <batchOperation :select-list="selectList" :isEnabledPassword="isEnabledPassword" @moveOrg="batchMoveOrg" @reloadList="reloadList"/>
             <bk-checkbox class="h-[32px] ml-[2px]"
                 :label="$t('仅显示本级用户')"
                 v-model="recursive"
@@ -222,7 +216,7 @@
   </template>
   
 <script setup lang="tsx">
-  import { ref, reactive, computed, inject, watch, Ref} from 'vue';
+  import { ref, reactive, computed, inject, watch} from 'vue';
   import { InfoBox, Message} from 'bkui-vue';
   import Empty from '@/components/SearchEmpty.vue'; 
   import { Upload} from 'bkui-vue/lib/icon'; 
@@ -298,16 +292,7 @@
     return appStore.currentTenant?.data_source?.id;
   });
   const isEnabledPassword = computed(() => {
-    return appStore.currentTenant?.data_source?.enable_password && isLocalDataSource.value;
-  })
-  const isEnabledMoveOrg = computed(() => isLocalDataSource.value)
-  const isEnabledDelPassword = computed(() => isLocalDataSource.value)
-  const permittedUpdateItems: Ref<string[] | null> = computed(() => {
-    if (!isLocalDataSource.value) {
-      const permittedType: string[] = ['date']
-      return permittedType
-    }
-    return null
+    return appStore.currentTenant?.data_source?.enable_password;
   })
 
   const isShowBtn = computed(() => {

--- a/src/pages/src/views/organization/components/table-list.vue
+++ b/src/pages/src/views/organization/components/table-list.vue
@@ -13,7 +13,13 @@
             </bk-button>
             <bk-button class="mr-[16px]" v-if="isShowBtn"
               @click="handleGetUsersDialog">{{ $t('拉取已有用户') }}</bk-button>
-            <batchOperation :select-list="selectList" :isEnabledPassword="isEnabledPassword" @moveOrg="batchMoveOrg" @reloadList="reloadList"/>
+            <batchOperation
+               :select-list="selectList"
+               :isEnabledPassword="isEnabledPassword"
+               :isEnabledMoveOrg="isEnabledMoveOrg"
+               :isEnabledDelPassword="isEnabledDelPassword"
+               :permittedUpdateItems="permittedUpdateItems"
+               @moveOrg="batchMoveOrg" @reloadList="reloadList"/>
             <bk-checkbox class="h-[32px] ml-[2px]"
                 :label="$t('仅显示本级用户')"
                 v-model="recursive"
@@ -216,7 +222,7 @@
   </template>
   
 <script setup lang="tsx">
-  import { ref, reactive, computed, inject, watch} from 'vue';
+  import { ref, reactive, computed, inject, watch, Ref} from 'vue';
   import { InfoBox, Message} from 'bkui-vue';
   import Empty from '@/components/SearchEmpty.vue'; 
   import { Upload} from 'bkui-vue/lib/icon'; 
@@ -292,7 +298,16 @@
     return appStore.currentTenant?.data_source?.id;
   });
   const isEnabledPassword = computed(() => {
-    return appStore.currentTenant?.data_source?.enable_password;
+    return appStore.currentTenant?.data_source?.enable_password && isLocalDataSource.value;
+  })
+  const isEnabledMoveOrg = computed(() => isLocalDataSource.value)
+  const isEnabledDelPassword = computed(() => isLocalDataSource.value)
+  const permittedUpdateItems: Ref<string[] | null> = computed(() => {
+    if (!isLocalDataSource.value) {
+      const permittedType: string[] = ['date']
+      return permittedType
+    }
+    return null
   })
 
   const isShowBtn = computed(() => {


### PR DESCRIPTION
1. 移动 、重置密码、删除 仅仅在本地数据源时起效，其他数据源类型都是禁用的
2. 修改用户信息，弹框，在数据源非本地时，仅仅可以修改有效期，其他都是不允许 # Reviewed, transaction id: 17207
