### PR TITLE
fix: added instruction for collecting static resources in Dockerfile

### DIFF
--- a/src/bk-user/Dockerfile
+++ b/src/bk-user/Dockerfile
@@ -42,4 +42,6 @@ COPY src/idp-plugins/idp_plugins /app/bkuser/idp_plugins
 COPY --from=StaticBuilding /dist /app/staticfiles
 COPY --from=StaticBuilding /dist/index.html /app/templates/index.html
 
+RUN python manage.py collectstatic --noinput
+
 CMD ["bash", "/app/bin/start.sh"]


### PR DESCRIPTION
### Description

添加 Dockerfile 中的指令，避免找不到 swagger 的静态资源，从而导致 swagger 页面无法渲染的问题

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
