### PR TITLE
Style/根据标准优化导航栏及layout样式

### DIFF
--- a/src/pages/src/views/MainHeader.vue
+++ b/src/pages/src/views/MainHeader.vue
@@ -91,7 +91,7 @@
             </template>
           </bk-dropdown>
           <bk-dropdown
-            class="pl-[10px]"
+            class="pl-[12px]"
             placement="bottom-end"
             @hide="() => (state.logoutDropdown = false)"
             @show="() => (state.logoutDropdown = true)"
@@ -270,7 +270,7 @@ const openVersionLog = async () => {
 }
 
 .main-navigation {
-  min-width: 1200px;
+  min-width: 1280px;
 
   :deep(.bk-navigation-header) {
     background-color: #0e1525;
@@ -364,7 +364,7 @@ const openVersionLog = async () => {
   text-decoration: none;
 
   &:hover {
-    color: #d3d9e4;
+    color: #c2cee5;
   }
 
   &.main-navigation-nav--active {

--- a/src/pages/src/views/setting/index.vue
+++ b/src/pages/src/views/setting/index.vue
@@ -23,7 +23,7 @@
           class="main-menu__toggle"
           @click="menuStore.toggle">
           <i
-            class="user-icon icon-arrow-left main-menu__icon"
+            class="user-icon icon-arrow-right main-menu__icon"
             :class="[{
               'main-menu__icon--active': menuStore.toggleCollapsed
             }]" />


### PR DESCRIPTION
1.将导航栏顶部用户名与图标间隔由原22px增加至24px
2.导航最窄宽度由原1200px改为1280px
3.修改顶部导航菜单hover时color
4.修改左侧菜单collapse图标展示方向