### PR TITLE
feat: 数据源配置loading

### DIFF
--- a/src/pages/src/hooks/useDataSource.ts
+++ b/src/pages/src/hooks/useDataSource.ts
@@ -101,7 +101,7 @@ export const useDataSource = () => {
       Message({ theme: res.data.status, message: res.data.summary });
       if (pollingInterval.value) return;
       initSyncRecords(stopOperationPollingRule);
-      pollingInterval.value = setInterval(() => initSyncRecords(stopOperationPollingRule), 10000);
+      pollingInterval.value = setInterval(() => initSyncRecords(stopOperationPollingRule), 5000);
     });
   };
 
@@ -124,7 +124,7 @@ export const useDataSource = () => {
     initSyncRecords(importDataStopRule);
     importDataTimePolling.value = setInterval(() => {
       initSyncRecords(importDataStopRule);
-    }, 1000);
+    }, 5000);
   };
 
   const stopImportDataTimePolling = () => {

--- a/src/pages/src/store/syncStatus.ts
+++ b/src/pages/src/store/syncStatus.ts
@@ -3,10 +3,14 @@ import { defineStore } from 'pinia';
 export const useSyncStatus = defineStore('syncStatus', {
   state: () => ({
     syncStatus: {},
+    isRefresh: true,
   }),
   actions: {
     setSyncStatus(syncStatus: any) {
       this.syncStatus = syncStatus;
+    },
+    setRefresh(isRefresh: boolean) {
+      this.isRefresh = isRefresh;
     },
   },
 });

--- a/src/pages/src/utils/index.ts
+++ b/src/pages/src/utils/index.ts
@@ -273,6 +273,7 @@ export const SYNC_TIMEOUT_LIST = [
 
 // 数据更新记录状态
 export const dataRecordStatus = {
+  // pending状态下文本由待执行改为同步中
   pending: {
     icon: loadingImg,
     text: t('同步中'),
@@ -294,6 +295,8 @@ export const dataRecordStatus = {
     theme: 'danger',
   },
 };
+
+export const RUNNING_FIELDS = ['pending', 'running'];
 
 // 有效期
 export const VALID_TIME = [

--- a/src/pages/src/utils/index.ts
+++ b/src/pages/src/utils/index.ts
@@ -275,7 +275,7 @@ export const SYNC_TIMEOUT_LIST = [
 export const dataRecordStatus = {
   pending: {
     icon: loadingImg,
-    text: t('待执行'),
+    text: t('同步中'),
     theme: 'warning',
   },
   running: {

--- a/src/pages/src/views/organization/components/table-list.vue
+++ b/src/pages/src/views/organization/components/table-list.vue
@@ -31,6 +31,7 @@
         </div>
         <bk-table
             max-height="100%"
+            min-height="30%"
             class="organization-table-main"
             :border="['outer']"
             :data="tableData"

--- a/src/pages/src/views/setting/data-source/ConfigList.vue
+++ b/src/pages/src/views/setting/data-source/ConfigList.vue
@@ -14,6 +14,7 @@
           hover-theme="primary"
           :loading="resetLoading"
           @click="handleReset"
+          :disabled="RUNNING_FIELDS.includes(syncStatus?.status)"
         >
           {{ $t('重置') }}
         </bk-button>
@@ -33,7 +34,7 @@
           <div class="flex items-center">
             <div class="mr-[40px]" v-if="syncStatus">
               <span
-                v-if="syncStatus?.status !== 'running' && syncStatus?.status !== 'pending'"
+                v-if="!RUNNING_FIELDS.includes(syncStatus?.status)"
                 :class="['tag-style', dataRecordStatus[syncStatus?.status]?.theme]">
                 {{ dataRecordStatus[syncStatus?.status]?.text }}
               </span>
@@ -41,7 +42,7 @@
                 <img :src="dataRecordStatus[syncStatus?.status]?.icon" class="h-[19.25px] w-[19.25px] mr-[9.37px]" />
                 <span>{{ dataRecordStatus[syncStatus?.status]?.text }}</span>
               </span>
-              <span v-if="syncStatus?.status !== 'running' && syncStatus?.status !== 'pending'">
+              <span v-if="!RUNNING_FIELDS.includes(syncStatus?.status)">
                 {{ syncStatus?.start_at }}
               </span>
             </div>
@@ -204,11 +205,10 @@ import MainBreadcrumbsDetails from '@/components/layouts/MainBreadcrumbsDetails.
 import SyncRecords from '@/components/SyncRecords.vue';
 import { useDataSource, useInfoBoxContent } from '@/hooks';
 import { deleteDataSources, getRelatedResource } from '@/http';
-import loadingImg from '@/images/loading.svg';
 import { t } from '@/language/index';
 import router from '@/router';
 import { useSyncStatus, useUser } from '@/store';
-import { dataRecordStatus } from '@/utils';
+import { dataRecordStatus, RUNNING_FIELDS } from '@/utils';
 const route = useRoute();
 
 const userStore = useUser();

--- a/src/pages/src/views/setting/data-source/ConfigList.vue
+++ b/src/pages/src/views/setting/data-source/ConfigList.vue
@@ -33,7 +33,7 @@
           <div class="flex items-center">
             <div class="mr-[40px]" v-if="syncStatus">
               <span
-                v-if="syncStatus?.status !== 'running'"
+                v-if="syncStatus?.status !== 'running' && syncStatus?.status !== 'pending'"
                 :class="['tag-style', dataRecordStatus[syncStatus?.status]?.theme]">
                 {{ dataRecordStatus[syncStatus?.status]?.text }}
               </span>
@@ -41,7 +41,9 @@
                 <img :src="dataRecordStatus[syncStatus?.status]?.icon" class="h-[19.25px] w-[19.25px] mr-[9.37px]" />
                 <span>{{ dataRecordStatus[syncStatus?.status]?.text }}</span>
               </span>
-              <span v-if="syncStatus?.status !== 'running'">{{ syncStatus?.start_at }}</span>
+              <span v-if="syncStatus?.status !== 'running' && syncStatus?.status !== 'pending'">
+                {{ syncStatus?.start_at }}
+              </span>
             </div>
             <div v-if="dataSource?.plugin_id === 'local'">
               <bk-button
@@ -248,12 +250,10 @@ const handleReset = async () => {
           deleteDataSources({ id: dataSource.value.id, is_delete_idp: resetConfig }).then(() => {
             Message({ theme: 'success', message: t('数据源重置成功') });
             initDataSourceList();
-          });
+          })
+            .finally(() => resetLoading.value = false);
         }
       },
-      onClose: () => {
-        resetLoading.value = false;
-      }
     });
   } catch (e) {
     console.warn(e);

--- a/src/pages/src/views/setting/data-source/ConfigList.vue
+++ b/src/pages/src/views/setting/data-source/ConfigList.vue
@@ -12,6 +12,7 @@
         <bk-button
           class="min-w-[64px]"
           hover-theme="primary"
+          :loading="resetLoading"
           @click="handleReset"
         >
           {{ $t('重置') }}
@@ -225,12 +226,13 @@ const {
   stopImportDataTimePolling,
 } = useDataSource();
 
+const resetLoading = ref(false);
 // 重置数据源
 const handleReset = async () => {
   try {
+    resetLoading.value = true;
     const res = await getRelatedResource(dataSource.value?.id);
     const { subContent, resetIdpConfig } = useInfoBoxContent(res.data, '');
-
 
     InfoBox({
       width: 600,
@@ -240,6 +242,7 @@ const handleReset = async () => {
       confirmText: t('重置'),
       theme: 'danger',
       onConfirm: () => {
+        resetLoading.value = true;
         const resetConfig = resetIdpConfig.value ? 'True' : 'False';
         if (dataSource.value?.id) {
           deleteDataSources({ id: dataSource.value.id, is_delete_idp: resetConfig }).then(() => {
@@ -248,9 +251,14 @@ const handleReset = async () => {
           });
         }
       },
+      onClose: () => {
+        resetLoading.value = false;
+      }
     });
   } catch (e) {
     console.warn(e);
+  } finally {
+    resetLoading.value = false;
   }
 };
 

--- a/src/pages/src/views/setting/data-source/ConfigSuccess.vue
+++ b/src/pages/src/views/setting/data-source/ConfigSuccess.vue
@@ -30,6 +30,7 @@ import { defineProps } from 'vue';
 
 import { useDataSource } from '@/hooks';
 import router from '@/router';
+import { useSyncStatus } from '@/store';
 
 defineProps({
   title: {
@@ -39,10 +40,11 @@ defineProps({
 });
 
 const { handleOperationsSync } = useDataSource();
-
+const syncStatusStore = useSyncStatus();
 // 同步数据后跳转到数据源配置页面
 const handleSync = () => {
   handleOperationsSync();
+  syncStatusStore.setRefresh(false);
   router.push({ name: 'dataSource' });
 };
 


### PR DESCRIPTION
1. 同步状态轮询请求统一改为5秒一次
2. 复组织管理因高度塌缩不显示loading
3. 重置按钮及重置过程新增loading
4. 执行中状态展示为同步中
5. 同步数据源时，重置button变为disabled状态
6. 载入或刷新页面时，对未同步状态的数据源建立轮询请求