### PR TITLE
fix: update csrf trusted origins in settings

### DIFF
--- a/src/bk-login/bklogin/settings.py
+++ b/src/bk-login/bklogin/settings.py
@@ -177,7 +177,7 @@ SESSION_COOKIE_NAME = f"bklogin_sessionid_{_BK_LOGIN_URL_MD5_16BIT}"
 SESSION_COOKIE_AGE = 60 * 60 * 24  # 1天
 CSRF_COOKIE_NAME = f"bklogin_csrftoken_{_BK_LOGIN_URL_MD5_16BIT}"
 # 对于特殊端口，带端口和不带端口都得添加，其他只需要添加默认原生的即可
-# Django 4.0 之后 CSRF_TRUSTED_ORIGINS 必须以 scheme （http:// 或 https://) 开头
+# Django 4.0 之后 CSRF_TRUSTED_ORIGINS 必须以 scheme (http:// 或 https://) 开头
 CSRF_TRUSTED_ORIGINS = (
     [f"{_BK_LOGIN_SCHEME}://{_BK_LOGIN_HOSTNAME}", f"{_BK_LOGIN_SCHEME}://{_BK_LOGIN_NETLOC}"]
     if _BK_LOGIN_IS_SPECIAL_PORT

--- a/src/bk-login/bklogin/settings.py
+++ b/src/bk-login/bklogin/settings.py
@@ -177,15 +177,16 @@ SESSION_COOKIE_NAME = f"bklogin_sessionid_{_BK_LOGIN_URL_MD5_16BIT}"
 SESSION_COOKIE_AGE = 60 * 60 * 24  # 1天
 CSRF_COOKIE_NAME = f"bklogin_csrftoken_{_BK_LOGIN_URL_MD5_16BIT}"
 # 对于特殊端口，带端口和不带端口都得添加，其他只需要添加默认原生的即可
-CSRF_TRUSTED_ORIGINS = [_BK_LOGIN_HOSTNAME, _BK_LOGIN_NETLOC] if _BK_LOGIN_IS_SPECIAL_PORT else [_BK_LOGIN_NETLOC]
-
-# cors
-CORS_ALLOW_CREDENTIALS = True  # 在 response 添加 Access-Control-Allow-Credentials, 即允许跨域使用 cookies
-CORS_ORIGIN_WHITELIST = (
+# Django 4.0 之后 CSRF_TRUSTED_ORIGINS 必须以 scheme （http:// 或 https://) 开头
+CSRF_TRUSTED_ORIGINS = (
     [f"{_BK_LOGIN_SCHEME}://{_BK_LOGIN_HOSTNAME}", f"{_BK_LOGIN_SCHEME}://{_BK_LOGIN_NETLOC}"]
     if _BK_LOGIN_IS_SPECIAL_PORT
     else [f"{_BK_LOGIN_SCHEME}://{_BK_LOGIN_NETLOC}"]
 )
+
+# cors
+CORS_ALLOW_CREDENTIALS = True  # 在 response 添加 Access-Control-Allow-Credentials, 即允许跨域使用 cookies
+CORS_ORIGIN_WHITELIST = CSRF_TRUSTED_ORIGINS
 # debug/联调测试时需要允许额外的域名跨域请求
 CORS_ORIGIN_ADDITIONAL_WHITELIST = env.list("CORS_ORIGIN_ADDITIONAL_WHITELIST", default=[])
 CORS_ORIGIN_WHITELIST.extend(CORS_ORIGIN_ADDITIONAL_WHITELIST)

--- a/src/bk-user/bkuser/settings.py
+++ b/src/bk-user/bkuser/settings.py
@@ -203,15 +203,16 @@ SESSION_COOKIE_DOMAIN = _BK_USER_HOSTNAME
 CSRF_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
 CSRF_COOKIE_NAME = f"bkuser_csrftoken_{_BK_USER_URL_MD5_16BIT}"
 # 对于特殊端口，带端口和不带端口都得添加，其他只需要添加默认原生的即可
-CSRF_TRUSTED_ORIGINS = [_BK_USER_HOSTNAME, _BK_USER_NETLOC] if _BK_USER_IS_SPECIAL_PORT else [_BK_USER_NETLOC]
-
-# cors
-CORS_ALLOW_CREDENTIALS = True  # 在 response 添加 Access-Control-Allow-Credentials, 即允许跨域使用 cookies
-CORS_ORIGIN_WHITELIST = (
+# Django 4.0 之后 CSRF_TRUSTED_ORIGINS 必须以 scheme （http:// 或 https://) 开头
+CSRF_TRUSTED_ORIGINS = (
     [f"{_BK_USER_SCHEME}://{_BK_USER_HOSTNAME}", f"{_BK_USER_SCHEME}://{_BK_USER_NETLOC}"]
     if _BK_USER_IS_SPECIAL_PORT
     else [f"{_BK_USER_SCHEME}://{_BK_USER_NETLOC}"]
 )
+
+# cors
+CORS_ALLOW_CREDENTIALS = True  # 在 response 添加 Access-Control-Allow-Credentials, 即允许跨域使用 cookies
+CORS_ORIGIN_WHITELIST = CSRF_TRUSTED_ORIGINS
 # debug/联调测试时需要允许额外的域名跨域请求
 CORS_ORIGIN_ADDITIONAL_WHITELIST = env.list("CORS_ORIGIN_ADDITIONAL_WHITELIST", default=[])
 CORS_ORIGIN_WHITELIST.extend(CORS_ORIGIN_ADDITIONAL_WHITELIST)

--- a/src/bk-user/bkuser/settings.py
+++ b/src/bk-user/bkuser/settings.py
@@ -203,7 +203,7 @@ SESSION_COOKIE_DOMAIN = _BK_USER_HOSTNAME
 CSRF_COOKIE_DOMAIN = SESSION_COOKIE_DOMAIN
 CSRF_COOKIE_NAME = f"bkuser_csrftoken_{_BK_USER_URL_MD5_16BIT}"
 # 对于特殊端口，带端口和不带端口都得添加，其他只需要添加默认原生的即可
-# Django 4.0 之后 CSRF_TRUSTED_ORIGINS 必须以 scheme （http:// 或 https://) 开头
+# Django 4.0 之后 CSRF_TRUSTED_ORIGINS 必须以 scheme (http:// 或 https://) 开头
 CSRF_TRUSTED_ORIGINS = (
     [f"{_BK_USER_SCHEME}://{_BK_USER_HOSTNAME}", f"{_BK_USER_SCHEME}://{_BK_USER_NETLOC}"]
     if _BK_USER_IS_SPECIAL_PORT


### PR DESCRIPTION
### Description

修复 Django 4.x 版本 settings.py 中 CSRF_TRUSTED_ORIGINS 必须以 scheme (http:// 或 https://) 开头

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
