### PR TITLE
fix: apis of tenant only support real data source

### DIFF
--- a/src/bk-user/bkuser/apis/open_v3/mixins.py
+++ b/src/bk-user/bkuser/apis/open_v3/mixins.py
@@ -46,10 +46,10 @@ class OpenApiCommonMixin:
 
     @cached_property
     def get_real_data_source_id(self) -> int:
-        data_source_id = (
+        data_source = (
             DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).only("id").first()
         )
-        if not data_source_id:
+        if not data_source:
             raise ValidationError(_("当前租户不存在实名用户数据源"))
 
-        return data_source_id
+        return data_source.id

--- a/src/bk-user/bkuser/apis/open_v3/mixins.py
+++ b/src/bk-user/bkuser/apis/open_v3/mixins.py
@@ -17,8 +17,13 @@
 from functools import cached_property
 
 from apigw_manager.drf.authentication import ApiGatewayJWTAuthentication
+from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
+
+from bkuser.apps.data_source.constants import DataSourceTypeEnum
+from bkuser.apps.data_source.models import DataSource
+from bkuser.common.error_codes import error_codes
 
 from .permissions import ApiGatewayAppVerifiedPermission
 
@@ -39,3 +44,10 @@ class OpenApiCommonMixin:
             raise ValidationError("X-Bk-Tenant-Id header is required")
 
         return tenant_id
+
+    def get_current_tenant_real_data_source(self) -> DataSource:
+        data_source = DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).first()
+        if not data_source:
+            raise error_codes.DATA_SOURCE_NOT_EXIST.f(_("当前租户不存在实名用户数据源"))
+
+        return data_source

--- a/src/bk-user/bkuser/apis/open_v3/mixins.py
+++ b/src/bk-user/bkuser/apis/open_v3/mixins.py
@@ -45,7 +45,7 @@ class OpenApiCommonMixin:
         return tenant_id
 
     @cached_property
-    def get_real_data_source_id(self) -> int:
+    def real_data_source_id(self) -> int:
         data_source = (
             DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).only("id").first()
         )

--- a/src/bk-user/bkuser/apis/open_v3/mixins.py
+++ b/src/bk-user/bkuser/apis/open_v3/mixins.py
@@ -23,7 +23,6 @@ from rest_framework.request import Request
 
 from bkuser.apps.data_source.constants import DataSourceTypeEnum
 from bkuser.apps.data_source.models import DataSource
-from bkuser.common.error_codes import error_codes
 
 from .permissions import ApiGatewayAppVerifiedPermission
 
@@ -45,9 +44,10 @@ class OpenApiCommonMixin:
 
         return tenant_id
 
-    def get_current_tenant_real_data_source(self) -> DataSource:
+    @cached_property
+    def get_real_data_source_id(self) -> int:
         data_source = DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).first()
         if not data_source:
-            raise error_codes.DATA_SOURCE_NOT_EXIST.f(_("当前租户不存在实名用户数据源"))
+            raise ValidationError(_("当前租户不存在实名用户数据源"))
 
-        return data_source
+        return data_source.id

--- a/src/bk-user/bkuser/apis/open_v3/mixins.py
+++ b/src/bk-user/bkuser/apis/open_v3/mixins.py
@@ -46,8 +46,10 @@ class OpenApiCommonMixin:
 
     @cached_property
     def get_real_data_source_id(self) -> int:
-        data_source = DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).first()
-        if not data_source:
+        data_source_id = (
+            DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).only("id").first()
+        )
+        if not data_source_id:
             raise ValidationError(_("当前租户不存在实名用户数据源"))
 
-        return data_source.id
+        return data_source_id

--- a/src/bk-user/bkuser/apis/open_v3/pagination.py
+++ b/src/bk-user/bkuser/apis/open_v3/pagination.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - 用户管理 (bk-user) available.
+# Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+
+from bkuser.common.pagination import CustomPageNumberPagination
+
+
+def get_pagination(max_page_size: int) -> type:
+    return type("Pagination", (CustomPageNumberPagination,), {"max_page_size": max_page_size})

--- a/src/bk-user/bkuser/apis/open_v3/pagination.py
+++ b/src/bk-user/bkuser/apis/open_v3/pagination.py
@@ -18,5 +18,5 @@
 from bkuser.common.pagination import CustomPageNumberPagination
 
 
-def get_pagination(max_page_size: int) -> type:
+def get_custom_page_number_pagination(max_page_size: int) -> type:
     return type("Pagination", (CustomPageNumberPagination,), {"max_page_size": max_page_size})

--- a/src/bk-user/bkuser/apis/open_v3/pagination.py
+++ b/src/bk-user/bkuser/apis/open_v3/pagination.py
@@ -18,7 +18,7 @@
 from bkuser.common.pagination import CustomPageNumberPagination
 
 
-def get_pagination_class(max_page_size: int):
+def gen_pagination_class(max_page_size: int):
     """根据不同的最大页数生成对应的 Pagination 类"""
 
     class Pagination(CustomPageNumberPagination):

--- a/src/bk-user/bkuser/apis/open_v3/pagination.py
+++ b/src/bk-user/bkuser/apis/open_v3/pagination.py
@@ -18,5 +18,11 @@
 from bkuser.common.pagination import CustomPageNumberPagination
 
 
-def get_custom_page_number_pagination(max_page_size: int) -> type:
-    return type("Pagination", (CustomPageNumberPagination,), {"max_page_size": max_page_size})
+def get_pagination_class(max_page_size: int):
+    """根据不同的最大页数生成对应的 Pagination 类"""
+
+    class Pagination(CustomPageNumberPagination):
+        def __init__(self):
+            self.max_page_size = max_page_size
+
+    return Pagination

--- a/src/bk-user/bkuser/apis/open_v3/views/department.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/department.py
@@ -41,7 +41,7 @@ class TenantDepartmentRetrieveApi(OpenApiCommonMixin, generics.RetrieveAPIView):
     lookup_url_kwarg = "id"
 
     def get_queryset(self):
-        return TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id)
+        return TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id=self.real_data_source_id)
 
     @swagger_auto_schema(
         tags=["open_v3.department"],
@@ -87,7 +87,7 @@ class TenantDepartmentListApi(OpenApiCommonMixin, generics.ListAPIView):
     )
     def get(self, request, *args, **kwargs):
         depts = TenantDepartment.objects.select_related("data_source_department").filter(
-            tenant=self.tenant_id, data_source_id=self.get_real_data_source_id
+            tenant=self.tenant_id, data_source_id=self.real_data_source_id
         )
 
         # 分页
@@ -119,7 +119,7 @@ class TenantDepartmentDescendantListApi(OpenApiCommonMixin, generics.ListAPIView
         data = slz.validated_data
 
         tenant_department = get_object_or_404(
-            TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id),
+            TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id=self.real_data_source_id),
             id=kwargs["id"],
         )
 

--- a/src/bk-user/bkuser/apis/open_v3/views/department.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/department.py
@@ -38,6 +38,11 @@ class TenantDepartmentRetrieveApi(OpenApiCommonMixin, generics.RetrieveAPIView):
     获取部门信息（支持是否包括祖先部门）
     """
 
+    lookup_url_kwarg = "id"
+
+    def get_queryset(self):
+        return TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id)
+
     @swagger_auto_schema(
         tags=["open_v3.department"],
         operation_id="retrieve_department",
@@ -50,12 +55,7 @@ class TenantDepartmentRetrieveApi(OpenApiCommonMixin, generics.RetrieveAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        tenant_department = get_object_or_404(
-            TenantDepartment.objects.filter(
-                tenant_id=self.tenant_id, data_source=self.get_current_tenant_real_data_source()
-            ),
-            id=kwargs["id"],
-        )
+        tenant_department = self.get_object()
 
         info = {
             "id": tenant_department.id,
@@ -87,7 +87,7 @@ class TenantDepartmentListApi(OpenApiCommonMixin, generics.ListAPIView):
     )
     def get(self, request, *args, **kwargs):
         depts = TenantDepartment.objects.select_related("data_source_department").filter(
-            tenant=self.tenant_id, data_source=self.get_current_tenant_real_data_source()
+            tenant=self.tenant_id, data_source_id=self.get_real_data_source_id
         )
 
         # 分页
@@ -119,9 +119,7 @@ class TenantDepartmentDescendantListApi(OpenApiCommonMixin, generics.ListAPIView
         data = slz.validated_data
 
         tenant_department = get_object_or_404(
-            TenantDepartment.objects.filter(
-                tenant_id=self.tenant_id, data_source=self.get_current_tenant_real_data_source()
-            ),
+            TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id),
             id=kwargs["id"],
         )
 

--- a/src/bk-user/bkuser/apis/open_v3/views/department.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/department.py
@@ -38,8 +38,6 @@ class TenantDepartmentRetrieveApi(OpenApiCommonMixin, generics.RetrieveAPIView):
     获取部门信息（支持是否包括祖先部门）
     """
 
-    serializer_class = TenantDepartmentRetrieveOutputSLZ
-
     @swagger_auto_schema(
         tags=["open_v3.department"],
         operation_id="retrieve_department",

--- a/src/bk-user/bkuser/apis/open_v3/views/user.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/user.py
@@ -24,7 +24,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
 from bkuser.apis.open_v3.mixins import OpenApiCommonMixin
-from bkuser.apis.open_v3.pagination import get_pagination_class
+from bkuser.apis.open_v3.pagination import gen_pagination_class
 from bkuser.apis.open_v3.serializers.user import (
     TenantUserDepartmentListInputSLZ,
     TenantUserDepartmentListOutputSLZ,
@@ -227,7 +227,7 @@ class TenantUserListApi(OpenApiCommonMixin, generics.ListAPIView):
     查询用户列表
     """
 
-    pagination_class = get_pagination_class(max_page_size=1000)
+    pagination_class = gen_pagination_class(max_page_size=1000)
 
     serializer_class = TenantUserListOutputSLZ
 

--- a/src/bk-user/bkuser/apis/open_v3/views/user.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/user.py
@@ -88,10 +88,6 @@ class TenantUserRetrieveApi(OpenApiCommonMixin, generics.RetrieveAPIView):
     根据用户 bk_username 获取用户信息
     """
 
-    queryset = TenantUser.objects.all()
-    lookup_url_kwarg = "id"
-    serializer_class = TenantUserRetrieveOutputSLZ
-
     @swagger_auto_schema(
         tags=["open_v3.user"],
         operation_id="retrieve_user",
@@ -114,8 +110,6 @@ class TenantUserDepartmentListApi(OpenApiCommonMixin, generics.ListAPIView):
     """
 
     pagination_class = None
-
-    serializer_class = TenantUserDepartmentListOutputSLZ
 
     @swagger_auto_schema(
         tags=["open_v3.user"],

--- a/src/bk-user/bkuser/apis/open_v3/views/user.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/user.py
@@ -66,7 +66,7 @@ class TenantUserDisplayNameListApi(OpenApiCommonMixin, generics.ListAPIView):
             TenantUser.objects.filter(
                 id__in=data["bk_usernames"],
                 tenant_id=self.tenant_id,
-                data_source_id=self.get_real_data_source_id,
+                data_source_id=self.real_data_source_id,
             )
             .select_related("data_source_user")
             .only("id", "data_source_user__full_name")
@@ -92,7 +92,7 @@ class TenantUserRetrieveApi(OpenApiCommonMixin, generics.RetrieveAPIView):
     serializer_class = TenantUserRetrieveOutputSLZ
 
     def get_queryset(self):
-        return TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id)
+        return TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id=self.real_data_source_id)
 
     @swagger_auto_schema(
         tags=["open_v3.user"],
@@ -124,7 +124,7 @@ class TenantUserDepartmentListApi(OpenApiCommonMixin, generics.ListAPIView):
         data = slz.validated_data
 
         tenant_user = get_object_or_404(
-            TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id),
+            TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id=self.real_data_source_id),
             id=kwargs["id"],
         )
 
@@ -200,7 +200,7 @@ class TenantUserLeaderListApi(OpenApiCommonMixin, generics.ListAPIView):
 
     def get_queryset(self) -> QuerySet[TenantUser]:
         tenant_user = get_object_or_404(
-            TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id),
+            TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id=self.real_data_source_id),
             id=self.kwargs["id"],
         )
 
@@ -234,7 +234,7 @@ class TenantUserListApi(OpenApiCommonMixin, generics.ListAPIView):
     def get_queryset(self) -> QuerySet[TenantUser]:
         return (
             TenantUser.objects.select_related("data_source_user")
-            .filter(tenant_id=self.tenant_id, data_source_id=self.get_real_data_source_id)
+            .filter(tenant_id=self.tenant_id, data_source_id=self.real_data_source_id)
             .only("id", "data_source_user__full_name")
         )
 

--- a/src/bk-user/bkuser/apis/open_v3/views/user.py
+++ b/src/bk-user/bkuser/apis/open_v3/views/user.py
@@ -24,7 +24,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
 from bkuser.apis.open_v3.mixins import OpenApiCommonMixin
-from bkuser.apis.open_v3.pagination import get_pagination
+from bkuser.apis.open_v3.pagination import get_custom_page_number_pagination
 from bkuser.apis.open_v3.serializers.user import (
     TenantUserDepartmentListInputSLZ,
     TenantUserDepartmentListOutputSLZ,
@@ -237,7 +237,7 @@ class TenantUserListApi(OpenApiCommonMixin, generics.ListAPIView):
     查询用户列表
     """
 
-    pagination_class = get_pagination(max_page_size=1000)
+    pagination_class = get_custom_page_number_pagination(max_page_size=1000)
 
     serializer_class = TenantUserListOutputSLZ
 


### PR DESCRIPTION
### Description

OpenAPI 一些通用问题优化：

1. 只允许查询 实名数据源 相关数据，虚拟和内置管理数据源都不允许返回（无论是用户还是部门，只查询实名数据源的数据）
2. TenantUserListApi 分页问题，不能直接修改类属性，会影响其他接口的分页

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
