### PR TITLE
fix: replace hardcoded secrets with env-configurable values

### DIFF
--- a/src/api/bkuser_core/config/common/django_basic.py
+++ b/src/api/bkuser_core/config/common/django_basic.py
@@ -13,7 +13,7 @@ import os
 from . import PROJECT_ROOT, env
 
 # only for django itself(internal hashes), not a specific identity
-SECRET_KEY = "Zfljnbga5QYVqNpOXLwhfGQLplZHHj3FuQWdAcaqTiDrDUfsTS"
+SECRET_KEY = env.str("SECRET_KEY", default="Zfljnbga5QYVqNpOXLwhfGQLplZHHj3FuQWdAcaqTiDrDUfsTS")
 
 SITE_URL = "/"
 

--- a/src/api/bkuser_core/config/common/platform.py
+++ b/src/api/bkuser_core/config/common/platform.py
@@ -98,8 +98,12 @@ BK_APIGW_RESOURCE_DOCS_BASE_DIR = os.path.join(PROJECT_ROOT, "resources/apigatew
 # ===============================================================================
 # API 访问限制（暂未开启）
 # ===============================================================================
-INTERNAL_AUTH_TOKENS = {"TCwCnoiuUgPccj8y0Wx187vJBqzqddfLlm": {"username": "iadmin"}}
-ACCESS_APP_WHITE_LIST = {"bk-iam": "lLP3gabV8M0C9vbwHQwzSYJX3WumcJsDSdVNQtq6FJVCLqJX6o"}
+INTERNAL_AUTH_TOKENS = env.json(
+    "INTERNAL_AUTH_TOKENS", default={"TCwCnoiuUgPccj8y0Wx187vJBqzqddfLlm": {"username": "iadmin"}}
+)
+ACCESS_APP_WHITE_LIST = env.json(
+    "ACCESS_APP_WHITE_LIST", default={"bk-iam": "lLP3gabV8M0C9vbwHQwzSYJX3WumcJsDSdVNQtq6FJVCLqJX6o"}
+)
 
 ENABLE_API_AUTH = env.bool("ENABLE_API_AUTH", default=False)
 if ENABLE_API_AUTH:

--- a/src/build/api/support-files/templates/api#bkuser_core#config#overlays#prod.py
+++ b/src/build/api/support-files/templates/api#bkuser_core#config#overlays#prod.py
@@ -141,8 +141,8 @@ ACTION_ID_HEADER = "HTTP_ACTION_ID"
 # ===============================================================================
 # API 访问限制（暂未开启）
 # ===============================================================================
-INTERNAL_AUTH_TOKENS = {"TCwCnoiuUgPccj8y0Wx187vJBqzqddfLlm": {"username": "iadmin"}}
-ACCESS_APP_WHITE_LIST = {"bk-iam": "lLP3gabV8M0C9vbwHQwzSYJX3WumcJsDSdVNQtq6FJVCLqJX6o"}
+INTERNAL_AUTH_TOKENS = env.json("INTERNAL_AUTH_TOKENS", default={"TCwCnoiuUgPccj8y0Wx187vJBqzqddfLlm": {"username": "iadmin"}})
+ACCESS_APP_WHITE_LIST = env.json("ACCESS_APP_WHITE_LIST", default={"bk-iam": "lLP3gabV8M0C9vbwHQwzSYJX3WumcJsDSdVNQtq6FJVCLqJX6o"})
 
 
 # ==============================================================================

--- a/src/login/bklogin/config/default.py
+++ b/src/login/bklogin/config/default.py
@@ -38,7 +38,7 @@ ALLOWED_HOSTS = ["*"]
 DEBUG = env.bool("DEBUG", False)
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "o7(025idh*fj@)ohujum-ilfxl^n=@d&$xz!_$$7s$8jopd5r#"
+SECRET_KEY = env.str("SECRET_KEY", default="o7(025idh*fj@)ohujum-ilfxl^n=@d&$xz!_$$7s$8jopd5r#")
 
 CSRF_COOKIE_NAME = "bklogin_csrftoken"
 # CSRF 验证失败处理函数

--- a/src/saas/bkuser_shell/config/common/django_basic.py
+++ b/src/saas/bkuser_shell/config/common/django_basic.py
@@ -10,10 +10,10 @@ specific language governing permissions and limitations under the License.
 """
 import os
 
-from . import PROJECT_ROOT
+from . import PROJECT_ROOT, env
 
 # 应用密钥
-SECRET_KEY = "MQtd_0cw&AiY5jT&&#w7%9sCK=HW$O_e%ch4xDd*AaP(xU0s3X"
+SECRET_KEY = env.str("SECRET_KEY", default="MQtd_0cw&AiY5jT&&#w7%9sCK=HW$O_e%ch4xDd*AaP(xU0s3X")
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
- SECRET_KEY in login, saas, api modules: read from SECRET_KEY env var with existing values as fallback defaults for dev environments
- INTERNAL_AUTH_TOKENS and ACCESS_APP_WHITE_LIST in api platform config and prod build template: read from env var (JSON format) to allow production deployments to use rotated credentials

### Description

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
