### PR TITLE
fix(departments): set explicit lookup_field for DepartmentProfileEdge…

### DIFF
--- a/src/api/bkuser_core/departments/v2/views.py
+++ b/src/api/bkuser_core/departments/v2/views.py
@@ -289,6 +289,7 @@ class DepartmentProfileEdgeViewSet(AdvancedModelViewSet, AdvancedListAPIView):
 
     queryset = DepartmentThroughModel.objects.filter(profile__enabled=True, department__enabled=True)
     serializer_class = local_serializers.DepartmentProfileEdgesSLZ
+    lookup_field = "id"
     ordering = ["id"]
     ordering_fields = ["id", "department_id", "profile_id"]
 


### PR DESCRIPTION
…ViewSet

When lookup_field is not provided in query params, DRF defaults to 'pk' which is not in ALLOWED_LOOKUP_FIELDS, causing a 400 FIELDS_NOT_SUPPORTED_YET error on list_edges_department_profile API. Set lookup_field = 'id' to fix.

### Description

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
