### PR TITLE
refactor(open_web): unify data source queries via DataSourceCache

### DIFF
--- a/src/bk-user/bkuser/apis/open_v3/mixins.py
+++ b/src/bk-user/bkuser/apis/open_v3/mixins.py
@@ -23,8 +23,7 @@ from django.utils.translation import override
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
-from bkuser.apps.data_source.constants import DataSourceTypeEnum
-from bkuser.apps.data_source.models import DataSource
+from bkuser.apps.data_source.cache import DataSourceCache
 
 from .permissions import ApiGatewayAppVerifiedPermission
 
@@ -48,24 +47,13 @@ class OpenApiCommonMixin:
 
     @cached_property
     def real_data_source_ids(self) -> List[int]:
-        return list(
-            DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).values_list(
-                "id", flat=True
-            )
-        )
+        """本租户拥有的 REAL 数据源 ID，基于全局缓存避免 DB 查询"""
+        return list(DataSourceCache.real_ids_by_owner(self.tenant_id))
 
     @cached_property
     def virtual_data_source_id(self) -> int:
-        # 虚拟数据源不存在时，返回 0
-        data_source = (
-            DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.VIRTUAL)
-            .only("id")
-            .first()
-        )
-        if not data_source:
-            return 0
-
-        return data_source.id
+        """本租户的虚拟数据源 ID，不存在时返回 0，基于全局缓存避免 DB 查询"""
+        return DataSourceCache.virtual_id_by_owner(self.tenant_id)
 
     # 将 API 响应内容的默认语言设置为英文
     @method_decorator(override("en-us"))

--- a/src/bk-user/bkuser/apis/open_web/mixins.py
+++ b/src/bk-user/bkuser/apis/open_web/mixins.py
@@ -25,10 +25,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 
-from bkuser.apps.data_source.constants import DataSourceTypeEnum
-from bkuser.apps.data_source.models import DataSource
-from bkuser.apps.tenant.constants import CollaborationStrategyStatus
-from bkuser.apps.tenant.models import CollaborationStrategy
+from bkuser.apps.data_source.cache import DataSourceCache
 
 
 class OpenWebApiCommonMixin:
@@ -90,37 +87,10 @@ class OpenWebApiCommonMixin:
 
     @cached_property
     def real_data_source_ids(self) -> List[int]:
-        return list(
-            DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.REAL).values_list(
-                "id", flat=True
-            )
-        )
-
-    @cached_property
-    def collaboration_data_source_ids(self) -> List[int]:
-        collaboration_tenant_ids = list(
-            CollaborationStrategy.objects.filter(target_tenant_id=self.tenant_id)
-            .exclude(target_status=CollaborationStrategyStatus.UNCONFIRMED)
-            .values_list("source_tenant_id", flat=True)
-        )
-
-        if not collaboration_tenant_ids:
-            return []
-        return list(
-            DataSource.objects.filter(
-                owner_tenant_id__in=collaboration_tenant_ids, type=DataSourceTypeEnum.REAL
-            ).values_list("id", flat=True)
-        )
+        """本租户拥有的 REAL 数据源 ID（不含协同），基于全局缓存避免 DB 查询"""
+        return list(DataSourceCache.real_ids_by_owner(self.tenant_id))
 
     @cached_property
     def virtual_data_source_id(self) -> int:
-        # 虚拟数据源不存在时，返回 0
-        data_source = (
-            DataSource.objects.filter(owner_tenant_id=self.tenant_id, type=DataSourceTypeEnum.VIRTUAL)
-            .only("id")
-            .first()
-        )
-        if not data_source:
-            return 0
-
-        return data_source.id
+        """本租户的虚拟数据源 ID，不存在时返回 0，基于全局缓存避免 DB 查询"""
+        return DataSourceCache.virtual_id_by_owner(self.tenant_id)

--- a/src/bk-user/bkuser/apis/open_web/serializers/departments.py
+++ b/src/bk-user/bkuser/apis/open_web/serializers/departments.py
@@ -20,7 +20,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from bkuser.apps.data_source.cache import get_data_source_owner_tenant_id
+from bkuser.apps.data_source.cache import DataSourceCache
 from bkuser.apps.tenant.models import TenantDepartment, TenantUser
 from bkuser.common.serializers import StringArrayField
 
@@ -39,7 +39,7 @@ class TenantDepartmentSearchOutputSLZ(serializers.Serializer):
     has_user = serializers.SerializerMethodField(help_text="是否有用户")
 
     def get_owner_tenant_id(self, obj: TenantDepartment) -> str:
-        return get_data_source_owner_tenant_id(obj.data_source_id)
+        return DataSourceCache.get_owner_tenant_id(obj.data_source_id)
 
     def get_organization_path(self, obj: TenantDepartment) -> str:
         return self.context["org_path_map"][obj.data_source_department_id]
@@ -110,7 +110,7 @@ class TenantDepartmentLookupOutputSLZ(serializers.Serializer):
     organization_path = serializers.SerializerMethodField(help_text="组织路径")
 
     def get_owner_tenant_id(self, obj: TenantDepartment) -> str:
-        return get_data_source_owner_tenant_id(obj.data_source_id)
+        return DataSourceCache.get_owner_tenant_id(obj.data_source_id)
 
     def get_organization_path(self, obj: TenantDepartment) -> str:
         return self.context["org_path_map"][obj.data_source_department_id]

--- a/src/bk-user/bkuser/apis/open_web/serializers/users.py
+++ b/src/bk-user/bkuser/apis/open_web/serializers/users.py
@@ -21,7 +21,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from bkuser.apps.data_source.cache import get_data_source_owner_tenant_id, get_data_source_type
+from bkuser.apps.data_source.cache import DataSourceCache
 from bkuser.apps.data_source.constants import DataSourceTypeEnum
 from bkuser.apps.tenant.constants import TenantUserStatus
 from bkuser.apps.tenant.models import TenantUser
@@ -79,7 +79,7 @@ class TenantUserSearchOutputSLZ(serializers.Serializer):
     organization_paths = serializers.SerializerMethodField(help_text="用户所属部门路径")
 
     def get_owner_tenant_id(self, obj: TenantUser) -> str:
-        return get_data_source_owner_tenant_id(obj.data_source_id)
+        return DataSourceCache.get_owner_tenant_id(obj.data_source_id)
 
     def get_login_name(self, obj: TenantUser) -> str:
         return self.context["login_name_map"][obj.id]
@@ -139,10 +139,10 @@ class TenantUserLookupOutputSLZ(serializers.Serializer):
     organization_paths = serializers.SerializerMethodField(help_text="用户所属部门路径")
 
     def get_data_source_type(self, obj: TenantUser) -> str:
-        return get_data_source_type(obj.data_source_id)
+        return DataSourceCache.get_type(obj.data_source_id)
 
     def get_owner_tenant_id(self, obj: TenantUser) -> str:
-        return get_data_source_owner_tenant_id(obj.data_source_id)
+        return DataSourceCache.get_owner_tenant_id(obj.data_source_id)
 
     def get_login_name(self, obj: TenantUser) -> str:
         return self.context["login_name_map"][obj.id]

--- a/src/bk-user/bkuser/apis/open_web/views/departments.py
+++ b/src/bk-user/bkuser/apis/open_web/views/departments.py
@@ -37,12 +37,8 @@ from bkuser.apis.open_web.serializers.departments import (
     TenantDepartmentUserListOutputSLZ,
 )
 from bkuser.apis.open_web.throttle import open_web_api_throttle_class
-from bkuser.apps.data_source.constants import DataSourceTypeEnum
-from bkuser.apps.data_source.models import (
-    DataSource,
-    DataSourceDepartmentRelation,
-    DataSourceDepartmentUserRelation,
-)
+from bkuser.apps.data_source.cache import DataSourceCache
+from bkuser.apps.data_source.models import DataSourceDepartmentRelation, DataSourceDepartmentUserRelation
 from bkuser.apps.tenant.models import TenantDepartment, TenantUser
 from bkuser.biz.organization import TenantDepartmentHandler, TenantOrgPathHandler
 from bkuser.biz.tenant import TenantUserDisplayNameHandler
@@ -70,11 +66,11 @@ class TenantDepartmentSearchApi(OpenWebApiCommonMixin, generics.ListAPIView):
             "data_source_department__name__icontains": data["keyword"],
         }
 
-        # 若指定了 owner_tenant_id，则只搜索该租户下的用户；否则搜索本租户用户与协同租户用
+        # 若指定了 owner_tenant_id，则只搜索该租户的 REAL 数据源部门；否则搜索所有 REAL 数据源部门
         if tenant_id := data.get("owner_tenant_id"):
-            filters["data_source_id__in"] = DataSource.objects.filter(owner_tenant_id=tenant_id).values_list(
-                "id", flat=True
-            )
+            filters["data_source_id__in"] = DataSourceCache.real_ids_by_owner(tenant_id)
+        else:
+            filters["data_source_id__in"] = DataSourceCache.real_ids()
 
         queryset = TenantDepartment.objects.filter(**filters).select_related("data_source_department")
 
@@ -112,10 +108,13 @@ class TenantDepartmentChildrenListApi(OpenWebApiCommonMixin, generics.ListAPIVie
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
+        real_ds_ids = DataSourceCache.real_ids()
+
         # 如果指定部门 ID 不为 0，则获取其子部门
         if parent_department_id := self.kwargs["id"]:
             tenant_department = get_object_or_404(
-                TenantDepartment.objects.filter(tenant_id=self.tenant_id), id=parent_department_id
+                TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id__in=real_ds_ids),
+                id=parent_department_id,
             )
 
             relation = DataSourceDepartmentRelation.objects.get(
@@ -126,19 +125,18 @@ class TenantDepartmentChildrenListApi(OpenWebApiCommonMixin, generics.ListAPIVie
 
         else:
             # 若指定部门 ID 为 0，则其子部门即为根部门
-            data_sources = DataSource.objects.filter(
-                owner_tenant_id=data["owner_tenant_id"], type=DataSourceTypeEnum.REAL
-            )
+            owner_real_ds_ids = DataSourceCache.real_ids_by_owner(data["owner_tenant_id"])
 
             data_source_dept_ids = (
                 DataSourceDepartmentRelation.objects.root_nodes()
-                .filter(data_source__in=data_sources)
+                .filter(data_source_id__in=owner_real_ds_ids)
                 .values_list("department_id", flat=True)
             )
 
         return TenantDepartment.objects.filter(
             tenant_id=self.tenant_id,
             data_source_department_id__in=data_source_dept_ids,
+            data_source_id__in=real_ds_ids,
         ).select_related("data_source_department")
 
     @swagger_auto_schema(
@@ -173,14 +171,16 @@ class TenantDepartmentUserListApi(OpenWebApiCommonMixin, generics.ListAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        queryset = TenantUser.objects.filter(
-            tenant_id=self.tenant_id, data_source__type=DataSourceTypeEnum.REAL
-        ).select_related("data_source_user")
+        real_ds_ids = DataSourceCache.real_ids()
+
+        queryset = TenantUser.objects.filter(tenant_id=self.tenant_id, data_source_id__in=real_ds_ids).select_related(
+            "data_source_user"
+        )
 
         # 若指定部门 ID 不为 0，则获取部门下的用户
         if department_id := self.kwargs["id"]:
             tenant_department = get_object_or_404(
-                TenantDepartment.objects.filter(tenant_id=self.tenant_id),
+                TenantDepartment.objects.filter(tenant_id=self.tenant_id, data_source_id__in=real_ds_ids),
                 id=department_id,
             )
 
@@ -192,16 +192,14 @@ class TenantDepartmentUserListApi(OpenWebApiCommonMixin, generics.ListAPIView):
 
         # 若指定部门 ID 为 0，则返回无部门的用户
         else:
-            data_sources = DataSource.objects.filter(
-                owner_tenant_id=data["owner_tenant_id"], type=DataSourceTypeEnum.REAL
-            )
+            owner_real_ds_ids = DataSourceCache.real_ids_by_owner(data["owner_tenant_id"])
             # Q: 为什么这里使用 `data_source_user__datasourcedepartmentuserrelation__isnull=True`
             #    join + isnull 写法来获取无部门用户，而不是 `exclude(子查询)` 或在 Python 里做 set 差集？
             # A: 该写法会让数据库直接执行 LEFT JOIN ... IS NULL 来筛选“无部门用户”，
             #    能在一条 SQL 内完成过滤，避免 `exclude(子查询)` 带来的额外子查询复杂度，
             #    同时避免把大量用户 ID 拉到 Python 侧做集合运算造成的内存/网络开销（大数据量下耗时明显）。
             queryset = queryset.filter(
-                data_source__in=data_sources,
+                data_source_id__in=owner_real_ds_ids,
                 data_source_user__datasourcedepartmentuserrelation__isnull=True,
             )
 
@@ -235,9 +233,11 @@ class TenantDepartmentLookupApi(OpenWebApiCommonMixin, generics.ListAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        return TenantDepartment.objects.filter(id__in=data["department_ids"], tenant_id=self.tenant_id).select_related(
-            "data_source_department"
-        )
+        return TenantDepartment.objects.filter(
+            id__in=data["department_ids"],
+            tenant_id=self.tenant_id,
+            data_source_id__in=DataSourceCache.real_ids(),
+        ).select_related("data_source_department")
 
     @swagger_auto_schema(
         tags=["open_web.department"],

--- a/src/bk-user/bkuser/apis/open_web/views/users.py
+++ b/src/bk-user/bkuser/apis/open_web/views/users.py
@@ -44,8 +44,7 @@ from bkuser.apis.open_web.serializers.users import (
     VirtualUserSearchOutputSLZ,
 )
 from bkuser.apis.open_web.throttle import open_web_api_throttle_class
-from bkuser.apps.data_source.cache import get_data_source_id_to_owner_tenant_id_map, get_data_source_id_to_type_map
-from bkuser.apps.data_source.constants import DataSourceTypeEnum
+from bkuser.apps.data_source.cache import DataSourceCache
 from bkuser.apps.tenant.models import TenantUser
 from bkuser.biz.organization import TenantOrgPathHandler
 from bkuser.biz.tenant import TenantUserDisplayNameHandler, TenantUserHandler
@@ -70,9 +69,7 @@ class TenantUserDisplayInfoRetrieveApi(OpenWebApiCommonMixin, generics.RetrieveA
         tenant_user = get_object_or_404(
             TenantUser.objects.filter(
                 tenant_id=self.tenant_id,
-                data_source_id__in=self.real_data_source_ids
-                + self.collaboration_data_source_ids
-                + [self.virtual_data_source_id],
+                data_source_id__in=DataSourceCache.non_builtin_management_ids(),
             ).select_related("data_source_user"),
             id=kwargs["id"],
         )
@@ -101,13 +98,10 @@ class TenantUserDisplayInfoListApi(OpenWebApiCommonMixin, generics.ListAPIView):
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
-        # 后续支持表达式，则需要查询表达式可配置的所有字段
         return TenantUser.objects.filter(
             id__in=data["bk_usernames"],
             tenant_id=self.tenant_id,
-            data_source_id__in=self.real_data_source_ids
-            + self.collaboration_data_source_ids
-            + [self.virtual_data_source_id],
+            data_source_id__in=DataSourceCache.non_builtin_management_ids(),
         ).select_related("data_source_user")
 
     @swagger_auto_schema(
@@ -165,9 +159,11 @@ class TenantUserSearchApi(OpenWebApiCommonMixin, generics.ListAPIView):
             tenant_id=self.tenant_id, keyword=keyword
         )
 
-        # 通过缓存映射计算允许的 data_source_id 集合，避免 JOIN data_source 表
-        type_map = get_data_source_id_to_type_map()
-        real_ds_ids = {ds_id for ds_id, t in type_map.items() if t == DataSourceTypeEnum.REAL}
+        # 若指定了 owner_tenant_id，则只搜索该租户的 REAL 数据源用户；否则搜索所有 REAL 数据源用户
+        if tenant_id := data.get("owner_tenant_id"):
+            real_ds_ids = DataSourceCache.real_ids_by_owner(tenant_id)
+        else:
+            real_ds_ids = DataSourceCache.real_ids()
 
         filter_args = [
             Q(tenant_id=self.tenant_id),
@@ -176,13 +172,6 @@ class TenantUserSearchApi(OpenWebApiCommonMixin, generics.ListAPIView):
             | search_conditions,
             Q(data_source_id__in=real_ds_ids),
         ]
-
-        # 若指定了 owner_tenant_id，则只搜索该租户下的用户；否则搜索本租户用户与协同租户用户
-        if tenant_id := data.get("owner_tenant_id"):
-            owner_map = get_data_source_id_to_owner_tenant_id_map()
-            filter_args.append(
-                Q(data_source_id__in={ds_id for ds_id, owner in owner_map.items() if owner == tenant_id})
-            )
 
         queryset = TenantUser.objects.filter(*filter_args).select_related("data_source_user")[: self.search_limit]
 
@@ -243,16 +232,16 @@ class TenantUserLookupApi(OpenWebApiCommonMixin, generics.ListAPIView):
             condition,
         ]
 
-        # 通过缓存映射计算允许的 data_source_id 集合，避免 JOIN data_source 表
+        # 通过缓存映射计算允许的 data_source_id 集合，避免 JOIN data_source 表 data_source_type 字段
         if data_source_type := data.get("data_source_type"):
-            type_map = get_data_source_id_to_type_map()
-            filter_args.append(Q(data_source_id__in={ds_id for ds_id, t in type_map.items() if t == data_source_type}))
+            filter_args.append(Q(data_source_id__in=DataSourceCache.ids_by_type(data_source_type)))
+        else:
+            # 未指定类型时，排除内置管理数据源
+            filter_args.append(Q(data_source_id__in=DataSourceCache.non_builtin_management_ids()))
 
+        # 通过缓存映射计算允许的 data_source_id 集合，避免 JOIN data_source 表 owner_tenant_id 字段
         if tenant_id := data.get("owner_tenant_id"):
-            owner_map = get_data_source_id_to_owner_tenant_id_map()
-            filter_args.append(
-                Q(data_source_id__in={ds_id for ds_id, owner in owner_map.items() if owner == tenant_id})
-            )
+            filter_args.append(Q(data_source_id__in=DataSourceCache.ids_by_owner(tenant_id)))
 
         queryset = TenantUser.objects.filter(*filter_args).select_related("data_source_user")
 

--- a/src/bk-user/bkuser/apps/data_source/cache.py
+++ b/src/bk-user/bkuser/apps/data_source/cache.py
@@ -15,32 +15,82 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from typing import Dict, List
+from typing import Dict, List, Set, Tuple
 
+from bkuser.apps.data_source.constants import DataSourceTypeEnum
 from bkuser.apps.data_source.models import DataSource, DataSourceDepartmentRelation
 from bkuser.common.cache import Cache, CacheEnum, CacheKeyPrefixEnum, cached
 
 
-@cached(timeout=60)
-def get_data_source_id_to_owner_tenant_id_map() -> Dict[int, str]:
-    """数据源 ID → 归属租户 ID 全量映射（带 60s 缓存）"""
-    return dict(DataSource.objects.values_list("id", "owner_tenant_id"))
+class DataSourceCache:
+    """数据源基础信息缓存（单一底层缓存 + 多快捷方法）"""
 
+    @staticmethod
+    @cached(timeout=60)
+    def _get_infos() -> List[Tuple[int, str, str]]:
+        """底层缓存：[(id, type, owner_tenant_id), ...]"""
+        return list(DataSource.objects.values_list("id", "type", "owner_tenant_id"))
 
-def get_data_source_owner_tenant_id(data_source_id: int) -> str:
-    """获取单个数据源的归属租户 ID（基于全量缓存映射）"""
-    return get_data_source_id_to_owner_tenant_id_map()[data_source_id]
+    # ---------- 映射 ----------
 
+    @classmethod
+    def get_type_map(cls) -> Dict[int, str]:
+        """数据源 ID → 类型"""
+        return {ds_id: ds_type for ds_id, ds_type, _ in cls._get_infos()}
 
-@cached(timeout=60)
-def get_data_source_id_to_type_map() -> Dict[int, str]:
-    """数据源 ID → 类型全量映射（带 60s 缓存）"""
-    return dict(DataSource.objects.values_list("id", "type"))
+    @classmethod
+    def get_owner_tenant_id_map(cls) -> Dict[int, str]:
+        """数据源 ID → 归属租户 ID"""
+        return {ds_id: owner for ds_id, _, owner in cls._get_infos()}
 
+    # ---------- 单条查询 ----------
 
-def get_data_source_type(data_source_id: int) -> str:
-    """获取单个数据源的类型（基于全量缓存映射）"""
-    return get_data_source_id_to_type_map()[data_source_id]
+    @classmethod
+    def get_type(cls, data_source_id: int) -> str:
+        return cls.get_type_map()[data_source_id]
+
+    @classmethod
+    def get_owner_tenant_id(cls, data_source_id: int) -> str:
+        return cls.get_owner_tenant_id_map()[data_source_id]
+
+    # ---------- ID 集合快捷方法 ----------
+
+    @classmethod
+    def ids_by_type(cls, ds_type_filter: str) -> Set[int]:
+        """指定类型的所有数据源 ID"""
+        return {ds_id for ds_id, ds_type, _ in cls._get_infos() if ds_type == ds_type_filter}
+
+    @classmethod
+    def real_ids(cls) -> Set[int]:
+        """所有 REAL 类型数据源 ID"""
+        return {ds_id for ds_id, ds_type, _ in cls._get_infos() if ds_type == DataSourceTypeEnum.REAL}
+
+    @classmethod
+    def non_builtin_management_ids(cls) -> Set[int]:
+        """所有非内置管理类型数据源 ID（REAL + VIRTUAL）"""
+        return {ds_id for ds_id, ds_type, _ in cls._get_infos() if ds_type != DataSourceTypeEnum.BUILTIN_MANAGEMENT}
+
+    @classmethod
+    def real_ids_by_owner(cls, owner_tenant_id: str) -> Set[int]:
+        """指定归属租户的 REAL 类型数据源 ID"""
+        return {
+            ds_id
+            for ds_id, ds_type, owner in cls._get_infos()
+            if ds_type == DataSourceTypeEnum.REAL and owner == owner_tenant_id
+        }
+
+    @classmethod
+    def ids_by_owner(cls, owner_tenant_id: str) -> Set[int]:
+        """指定归属租户的所有数据源 ID（不限类型）"""
+        return {ds_id for ds_id, _, owner in cls._get_infos() if owner == owner_tenant_id}
+
+    @classmethod
+    def virtual_id_by_owner(cls, owner_tenant_id: str) -> int:
+        """指定归属租户的虚拟数据源 ID，不存在时返回 0"""
+        for ds_id, ds_type, owner in cls._get_infos():
+            if ds_type == DataSourceTypeEnum.VIRTUAL and owner == owner_tenant_id:
+                return ds_id
+        return 0
 
 
 class DepartmentAncestorCache:

--- a/src/bk-user/bkuser/biz/tenant/tenant_user.py
+++ b/src/bk-user/bkuser/biz/tenant/tenant_user.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional
 from django.conf import settings
 from pydantic import BaseModel
 
-from bkuser.apps.data_source.cache import get_data_source_owner_tenant_id
+from bkuser.apps.data_source.cache import DataSourceCache
 from bkuser.apps.tenant.models import TenantUser
 
 
@@ -58,9 +58,7 @@ class TenantUserHandler:
 
         对于协同过来的用户（即数据源所属租户 != 当前租户），加上来源租户 ID 作为后缀
         """
-        # data_source_id 是 TenantUser 本地字段，
-        # get_data_source_owner_tenant_id 基于内存全量短时效缓存，不产生多次 DB 查询
-        owner_tenant_id = get_data_source_owner_tenant_id(tenant_user.data_source_id)
+        owner_tenant_id = DataSourceCache.get_owner_tenant_id(tenant_user.data_source_id)
         if tenant_user.tenant_id != owner_tenant_id:
             return f"{tenant_user.data_source_user.username}@{owner_tenant_id}"
         return tenant_user.data_source_user.username


### PR DESCRIPTION
Replace scattered DB queries and function-based caching with a centralized DataSourceCache class backed by a single 60s-cached query. Remove the collaboration_data_source_ids mixin property in favor of broader cache methods guarded by tenant_id. Add missing ids_by_type() method to fix AttributeError in TenantUserLookupApi.

### Description

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
