### PR TITLE
refactor(data_source): make username generate config on-demand

### DIFF
--- a/src/bk-user/bkuser/apis/web/data_source/serializers.py
+++ b/src/bk-user/bkuser/apis/web/data_source/serializers.py
@@ -37,11 +37,11 @@ from bkuser.apps.data_source.models import (
     DataSource,
     DataSourcePlugin,
     DataSourceSensitiveInfo,
+    DataSourceUsernameGenerateConfig,
 )
 from bkuser.apps.sync.constants import DataSourceSyncPeriod, SyncTaskTrigger
 from bkuser.apps.sync.models import DataSourceSyncTask
 from bkuser.apps.tenant.models import TenantUserCustomField, UserBuiltinField
-from bkuser.biz.data_source import DataSourceUsernameHandler
 from bkuser.common.constants import SENSITIVE_MASK
 from bkuser.common.serializers import StringArrayField
 from bkuser.plugins.base import get_default_plugin_cfg, get_plugin_cfg_cls, is_plugin_exists
@@ -175,11 +175,15 @@ class DataSourceCreateInputSLZ(serializers.Serializer):
 
     def validate_username_generate_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
         # 校验同租户下 ADD_AFFIX 策略的前后缀组合唯一性
-        tenant_id = self.context["tenant_id"]
-        if config[
-            "rule"
-        ] == DataSourceUsernameGenerateRule.ADD_AFFIX and DataSourceUsernameHandler.is_username_affix_exists(
-            tenant_id, config["prefix"], config["suffix"]
+        if (
+            config["rule"] == DataSourceUsernameGenerateRule.ADD_AFFIX
+            and DataSourceUsernameGenerateConfig.objects.filter(
+                data_source__owner_tenant_id=self.context["tenant_id"],
+                data_source__type=DataSourceTypeEnum.REAL,
+                rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
+                prefix=config["prefix"],
+                suffix=config["suffix"],
+            ).exists()
         ):
             raise ValidationError(_("当前租户已存在相同用户名前后缀的数据源"))
 
@@ -251,7 +255,17 @@ class DataSourceRetrieveOutputSLZ(serializers.Serializer):
     plugin_config = serializers.JSONField(help_text="数据源插件配置")
     sync_config = serializers.JSONField(help_text="数据源同步任务配置")
     field_mapping = serializers.JSONField(help_text="用户字段映射")
-    username_generate_config = DataSourceUsernameGenerateConfigSLZ(help_text="用户名生成配置")
+    username_generate_config = serializers.SerializerMethodField(help_text="用户名生成配置")
+
+    def get_username_generate_config(self, obj: DataSource) -> Dict[str, str]:
+        cfg = (
+            DataSourceUsernameGenerateConfig.objects.filter(data_source_id=obj.id)
+            .values("rule", "prefix", "suffix")
+            .first()
+        )
+        if cfg is None:
+            return {"rule": DataSourceUsernameGenerateRule.UNCHANGED, "prefix": "", "suffix": ""}
+        return cfg
 
 
 class DataSourceUpdateInputSLZ(serializers.Serializer):

--- a/src/bk-user/bkuser/apis/web/data_source/views.py
+++ b/src/bk-user/bkuser/apis/web/data_source/views.py
@@ -53,7 +53,7 @@ from bkuser.apis.web.data_source.serializers import (
     LocalDataSourceImportInputSLZ,
 )
 from bkuser.apis.web.mixins import CurrentUserTenantMixin
-from bkuser.apps.data_source.constants import DataSourceTypeEnum
+from bkuser.apps.data_source.constants import DataSourceTypeEnum, DataSourceUsernameGenerateRule
 from bkuser.apps.data_source.models import (
     DataSource,
     DataSourceDepartment,
@@ -189,12 +189,14 @@ class DataSourceListCreateApi(CurrentUserTenantMixin, generics.ListCreateAPIView
 
             # 新实名数据源不会自动加入已有登录源。管理员确认数据 ready 后，需重新保存登录源配置。
             # 若未来需要自动追加，可复用已有主实名匹配规则调用 IdpDataSourceRelationHandler 追加关系。
-            DataSourceUsernameGenerateConfig.objects.create(
-                data_source=ds,
-                rule=data["username_generate_config"]["rule"],
-                prefix=data["username_generate_config"]["prefix"],
-                suffix=data["username_generate_config"]["suffix"],
-            )
+            cfg = data["username_generate_config"]
+            if cfg["rule"] == DataSourceUsernameGenerateRule.ADD_AFFIX:
+                DataSourceUsernameGenerateConfig.objects.create(
+                    data_source=ds,
+                    rule=cfg["rule"],
+                    prefix=cfg["prefix"],
+                    suffix=cfg["suffix"],
+                )
 
         # 【审计】创建数据源审计对象
         auditor = DataSourceAuditor(request.user.username, current_tenant_id)

--- a/src/bk-user/bkuser/apis/web/organization/serializers/users.py
+++ b/src/bk-user/bkuser/apis/web/organization/serializers/users.py
@@ -38,6 +38,7 @@ from bkuser.apps.data_source.models import (
     DataSourceUserLeaderRelation,
     LocalDataSourceIdentityInfo,
 )
+from bkuser.apps.data_source.transform import UsernameTransformer
 from bkuser.apps.tenant.constants import TenantUserStatus, UserFieldDataType
 from bkuser.apps.tenant.models import (
     CollaborationStrategy,
@@ -46,7 +47,6 @@ from bkuser.apps.tenant.models import (
     TenantUserCustomField,
     UserBuiltinField,
 )
-from bkuser.biz.data_source import DataSourceUsernameHandler
 from bkuser.biz.organization import TenantOrgPathHandler
 from bkuser.biz.validators import (
     validate_data_source_user_username,
@@ -154,12 +154,17 @@ def _validate_duplicate_username_in_tenant(
     tenant_id: str, username: str, excluded_data_source_user_id: int | None = None
 ) -> str:
     """校验当前租户实体数据源下用户名是否重复"""
-    real_ds_ids = DataSource.objects.filter(
-        owner_tenant_id=tenant_id,
-        type=DataSourceTypeEnum.REAL,
-    ).values_list("id", flat=True)
+    real_ds_ids = list(
+        DataSource.objects.filter(
+            owner_tenant_id=tenant_id,
+            type=DataSourceTypeEnum.REAL,
+        ).values_list("id", flat=True)
+    )
 
-    if DataSourceUsernameHandler.is_username_exists(real_ds_ids, username, excluded_data_source_user_id):
+    qs = DataSourceUser.objects.filter(data_source_id__in=real_ds_ids, username=username)
+    if excluded_data_source_user_id:
+        qs = qs.exclude(id=excluded_data_source_user_id)
+    if qs.exists():
         raise ValidationError(_("用户名 {} 已存在").format(username))
 
     return username
@@ -206,10 +211,11 @@ class TenantUserCreateInputSLZ(serializers.Serializer):
     )
 
     def validate_username(self, username: str) -> str:
-        username = DataSourceUsernameHandler.generate(self.context["data_source"], username)
-        # 最终的用户名需要再次校验
-        validate_data_source_user_username(username)
-        return _validate_duplicate_username_in_tenant(self.context["tenant_id"], username)
+        transform = UsernameTransformer.load(self.context["data_source"].id)
+        stored_username = transform.to_stored(username)
+        validate_data_source_user_username(stored_username)
+        _validate_duplicate_username_in_tenant(self.context["tenant_id"], stored_username)
+        return username
 
     def validate_department_ids(self, department_ids: List[int]) -> List[int]:
         invalid_department_ids = set(department_ids) - set(
@@ -517,7 +523,7 @@ class TenantUserBatchCreateInputSLZ(serializers.Serializer):
             # 注：raw_info 格式是以英文逗号 (,)、中文逗号 (，)、英文分号 (;) 或中文分号 (；)
             # 为分隔符的用户信息字符串，多选枚举以 / 拼接
             # 字段：username full_name email gender region hobbies
-            # 示例：kafka, 卡芙卡, kafka@starrail.com, 女, StarCoreHunter, 狩猎/阅读
+            # 示例：kafka, 卡芙卡，kafka@starrail.com, 女，StarCoreHunter, 狩猎/阅读
             data: List[str] = [s.strip() for s in re.split(r"[,，;；]", raw_info) if s.strip()]
             if len(data) != field_count:
                 raise ValidationError(
@@ -543,8 +549,7 @@ class TenantUserBatchCreateInputSLZ(serializers.Serializer):
             # 动态构建用户信息：内置字段直接添加，自定义字段放到 extras 中
             user_infos.append(
                 {
-                    # 根据 data_source 配置的规则，生成 username
-                    "username": DataSourceUsernameHandler.generate(self.context["data_source"], props["username"]),
+                    "username": props["username"],
                     "full_name": props["full_name"],
                     # 内置字段，联系方式允许非必填
                     "email": props.get("email", ""),
@@ -616,14 +621,17 @@ class TenantUserBatchCreateInputSLZ(serializers.Serializer):
         self, user_infos: List[Dict[str, Any]], custom_fields: QuerySet[TenantUserCustomField]
     ) -> None:
         """校验用户信息列表中数据是否合法"""
-        usernames = [u["username"].lower() for u in user_infos]
+        transform = UsernameTransformer.load(self.context["data_source"].id)
+
+        raw_usernames = [u["username"].lower() for u in user_infos]
         # 检查新增的数据是否有用户名重复的，需要忽略大小写，因为 DB 中是忽略的
-        counter = collections.Counter(usernames)
+        counter = collections.Counter(raw_usernames)
         if duplicate_usernames := [u for u, cnt in counter.items() if cnt > 1]:
             raise ValidationError(_("用户名 {} 重复").format(", ".join(duplicate_usernames)))
 
+        stored_usernames = [transform.to_stored(u["username"]).lower() for u in user_infos]
         if exists_usernames := DataSourceUser.objects.filter(
-            username__in=usernames,
+            username__in=stored_usernames,
             data_source__owner_tenant_id=self.context["tenant_id"],
             data_source__type=DataSourceTypeEnum.REAL,
         ).values_list("username", flat=True):

--- a/src/bk-user/bkuser/apis/web/organization/views/users.py
+++ b/src/bk-user/bkuser/apis/web/organization/views/users.py
@@ -66,6 +66,7 @@ from bkuser.apps.data_source.models import (
     DataSourceUser,
     DataSourceUserLeaderRelation,
 )
+from bkuser.apps.data_source.transform import UsernameTransformer
 from bkuser.apps.notification.tasks import send_reset_password_to_user
 from bkuser.apps.permission.constants import PermAction
 from bkuser.apps.permission.permissions import perm_class
@@ -88,7 +89,6 @@ from bkuser.biz.auditor import (
     TenantUserStatusUpdateAuditor,
     TenantUserUpdateAuditor,
 )
-from bkuser.biz.data_source import DataSourceUsernameHandler
 from bkuser.biz.organization import DataSourceUserHandler, TenantOrgPathHandler
 from bkuser.biz.password_rule import PasswordRuleHandler
 from bkuser.common.constants import PERMANENT_TIME
@@ -310,13 +310,16 @@ class TenantUserListCreateApi(CurrentUserTenantDataSourceMixin, generics.ListAPI
         slz.is_valid(raise_exception=True)
         data = slz.validated_data
 
+        transform = UsernameTransformer.load(data_source.id)
+        raw_username = data["username"]
+        stored_username = transform.to_stored(raw_username)
+
         with transaction.atomic():
             # 创建数据源用户
             data_source_user = DataSourceUser.objects.create(
                 data_source=data_source,
-                # 对于本地数据源，code 存放原始用户名
-                code=DataSourceUsernameHandler.parse(data_source, data["username"]),
-                username=data["username"],
+                code=raw_username,
+                username=stored_username,
                 full_name=data["full_name"],
                 email=data["email"],
                 phone=data["phone"],
@@ -798,13 +801,15 @@ class TenantUserBatchCreateApi(CurrentUserTenantDataSourceMixin, generics.Create
         if not tenant_dept:
             raise error_codes.TENANT_USER_CREATE_FAILED.f(_("指定的租户部门不存在"))
 
+        transform = UsernameTransformer.load(data_source.id)
+
         with transaction.atomic():
             # 新建数据源用户
             data_source_users = [
                 DataSourceUser(
                     data_source=data_source,
-                    code=DataSourceUsernameHandler.parse(data_source, info["username"]),
-                    username=info["username"],
+                    code=info["username"],
+                    username=transform.to_stored(info["username"]),
                     full_name=info["full_name"],
                     email=info["email"],
                     phone=info["phone"],
@@ -816,9 +821,8 @@ class TenantUserBatchCreateApi(CurrentUserTenantDataSourceMixin, generics.Create
             DataSourceUser.objects.bulk_create(data_source_users, batch_size=self.bulk_create_batch_size)
 
             # 重新从 DB 查询以获取带 ID 的数据源用户
-            data_source_users = DataSourceUser.objects.filter(
-                data_source=data_source, username__in=[u["username"] for u in data["user_infos"]]
-            )
+            stored_usernames = [transform.to_stored(u["username"]) for u in data["user_infos"]]
+            data_source_users = DataSourceUser.objects.filter(data_source=data_source, username__in=stored_usernames)
 
             # 绑定数据源部门 - 用户
             relations = [

--- a/src/bk-user/bkuser/apis/web/virtual_user/serializers.py
+++ b/src/bk-user/bkuser/apis/web/virtual_user/serializers.py
@@ -22,7 +22,6 @@ from rest_framework.exceptions import ValidationError
 
 from bkuser.apps.data_source.constants import DataSourceTypeEnum
 from bkuser.apps.tenant.models import TenantUser
-from bkuser.biz.data_source import DataSourceUsernameHandler
 from bkuser.biz.validators import validate_data_source_user_username
 
 
@@ -70,11 +69,6 @@ class VirtualUserCreateInputSLZ(serializers.Serializer):
     full_name = serializers.CharField(help_text="姓名")
     app_codes = serializers.ListField(help_text="应用编码列表", child=serializers.CharField())
     owners = serializers.ListField(help_text="责任人列表", child=serializers.CharField())
-
-    def validate_username(self, username: str) -> str:
-        if DataSourceUsernameHandler.is_username_exists([self.context["data_source_id"]], username):
-            raise ValidationError(_("用户名 {} 已存在").format(username))
-        return username
 
     def validate_app_codes(self, app_codes: List[str]) -> List[str]:
         # 过滤重复值

--- a/src/bk-user/bkuser/apps/data_source/migrations/0003_datasource_multi_source_support.py
+++ b/src/bk-user/bkuser/apps/data_source/migrations/0003_datasource_multi_source_support.py
@@ -19,32 +19,6 @@ from django.db import migrations, models
 import django.db.models.deletion
 
 
-def init_default_username_generate_configs(apps, schema_editor):
-    DataSource = apps.get_model("data_source", "DataSource")
-    DataSourceUsernameGenerateConfig = apps.get_model("data_source", "DataSourceUsernameGenerateConfig")
-
-    existing_config_data_source_ids = set(
-        DataSourceUsernameGenerateConfig.objects.values_list("data_source_id", flat=True)
-    )
-
-    to_create = []
-    for data_source_id in DataSource.objects.values_list("id", flat=True):
-        if data_source_id in existing_config_data_source_ids:
-            continue
-
-        to_create.append(
-            DataSourceUsernameGenerateConfig(
-                data_source_id=data_source_id,
-                rule="unchanged",
-                prefix="",
-                suffix="",
-            )
-        )
-
-    if to_create:
-        DataSourceUsernameGenerateConfig.objects.bulk_create(to_create)
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -62,14 +36,13 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
-                ('rule', models.CharField(choices=[('unchanged', '保持原始值'), ('add_affix', '添加前后缀')], default='unchanged', max_length=32, verbose_name='数据源用户名生成规则')),
+                ('rule', models.CharField(choices=[('unchanged', '保持原始值'), ('add_affix', '添加前后缀')], max_length=32, verbose_name='数据源用户名生成规则')),
                 ('prefix', models.CharField(blank=True, default='', max_length=32, verbose_name='用户名前缀')),
                 ('suffix', models.CharField(blank=True, default='', max_length=32, verbose_name='用户名后缀')),
-                ('data_source', models.OneToOneField(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, related_name='username_generate_config', to='data_source.datasource')),
+                ('data_source', models.OneToOneField(db_constraint=False, on_delete=django.db.models.deletion.CASCADE, to='data_source.datasource')),
             ],
             options={
                 'abstract': False,
             },
         ),
-        migrations.RunPython(init_default_username_generate_configs),
     ]

--- a/src/bk-user/bkuser/apps/data_source/models.py
+++ b/src/bk-user/bkuser/apps/data_source/models.py
@@ -265,16 +265,13 @@ class DataSourceSensitiveInfo(TimestampedModel):
 
 
 class DataSourceUsernameGenerateConfig(TimestampedModel):
-    """数据源用户名生成配置"""
+    """数据源用户名生成配置 — 仅在选择 ADD_AFFIX 策略时创建记录"""
 
-    data_source = models.OneToOneField(
-        DataSource, on_delete=models.CASCADE, db_constraint=False, related_name="username_generate_config"
-    )
+    data_source = models.OneToOneField(DataSource, on_delete=models.CASCADE, db_constraint=False)
     rule = models.CharField(
         "数据源用户名生成规则",
         max_length=32,
         choices=DataSourceUsernameGenerateRule.get_choices(),
-        default=DataSourceUsernameGenerateRule.UNCHANGED.value,
     )
     prefix = models.CharField("用户名前缀", max_length=32, blank=True, default="")
     suffix = models.CharField("用户名后缀", max_length=32, blank=True, default="")

--- a/src/bk-user/bkuser/apps/data_source/transform.py
+++ b/src/bk-user/bkuser/apps/data_source/transform.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - 用户管理 (bk-user) available.
+# Copyright (C) 2017 Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+
+from bkuser.apps.data_source.models import DataSourceUsernameGenerateConfig
+
+
+class UsernameTransformer:
+    """用户名转换器，负责原始用户名与存储用户名之间的转换"""
+
+    def __init__(self, prefix: str = "", suffix: str = ""):
+        self.prefix = prefix
+        self.suffix = suffix
+        self.unchanged = not prefix and not suffix
+
+    def to_stored(self, raw_username: str) -> str:
+        """原始用户名 → 存储用户名"""
+        if self.unchanged:
+            return raw_username
+
+        return f"{self.prefix}{raw_username}{self.suffix}"
+
+    def to_raw(self, stored_username: str) -> str:
+        """存储用户名 → 原始用户名"""
+        if self.unchanged:
+            return stored_username
+
+        result = stored_username
+        if self.prefix and result.startswith(self.prefix):
+            result = result[len(self.prefix) :]
+
+        if self.suffix and result.endswith(self.suffix):
+            result = result[: -len(self.suffix)]
+
+        return result
+
+    @classmethod
+    def load(cls, data_source_id: int) -> "UsernameTransformer":
+        """加载指定数据源的用户名转换器"""
+        row = (
+            DataSourceUsernameGenerateConfig.objects.filter(data_source_id=data_source_id)
+            .values_list("prefix", "suffix")
+            .first()
+        )
+
+        if row is None:
+            return cls()
+
+        return cls(prefix=row[0], suffix=row[1])

--- a/src/bk-user/bkuser/apps/sync/converters.py
+++ b/src/bk-user/bkuser/apps/sync/converters.py
@@ -26,11 +26,11 @@ from django.conf import settings
 from bkuser.apps.data_source.constants import FieldMappingOperation
 from bkuser.apps.data_source.data_models import DataSourceUserFieldMapping
 from bkuser.apps.data_source.models import DataSource, DataSourceUser
+from bkuser.apps.data_source.transform import UsernameTransformer
 from bkuser.apps.sync.constants import DATA_SOURCE_USERNAME_REGEX, EMAIL_REGEX
 from bkuser.apps.sync.loggers import TaskLogger
 from bkuser.apps.tenant.constants import UserFieldDataType
 from bkuser.apps.tenant.models import TenantUserCustomField, UserBuiltinField
-from bkuser.biz.data_source import DataSourceUsernameHandler
 from bkuser.common.validators import validate_phone_with_country_code
 from bkuser.plugins.models import RawDataSourceUser
 from bkuser.utils.pydantic import stringify_pydantic_error
@@ -42,6 +42,7 @@ class DataSourceUserConverter:
     def __init__(self, data_source: DataSource, logger: TaskLogger):
         self.data_source = data_source
         self.logger = logger
+        self.transformer = UsernameTransformer.load(data_source.id)
         self.custom_fields = TenantUserCustomField.objects.filter(tenant_id=self.data_source.owner_tenant_id)
         self.field_mapping = self._get_field_mapping()
 
@@ -55,8 +56,7 @@ class DataSourceUserConverter:
         if not username:
             raise ValueError("username is required")
 
-        # 根据数据源配置生成最终的用户名
-        username = DataSourceUsernameHandler.generate(self.data_source, username)
+        username = self.transformer.to_stored(username)
         if not re.fullmatch(DATA_SOURCE_USERNAME_REGEX, username):
             raise ValueError(f"username [{username}] not match pattern {DATA_SOURCE_USERNAME_REGEX.pattern}")
 

--- a/src/bk-user/bkuser/apps/sync/syncers/data_source_user.py
+++ b/src/bk-user/bkuser/apps/sync/syncers/data_source_user.py
@@ -31,11 +31,11 @@ from bkuser.apps.data_source.models import (
     DataSourceUser,
     DataSourceUserLeaderRelation,
 )
+from bkuser.apps.data_source.transform import UsernameTransformer
 from bkuser.apps.sync.constants import DataSourceSyncObjectType, SyncOperation
 from bkuser.apps.sync.contexts import DataSourceSyncTaskContext
 from bkuser.apps.sync.converters import DataSourceUserConverter
 from bkuser.apps.tenant.utils import is_username_frozen
-from bkuser.biz.data_source import DataSourceUsernameHandler
 from bkuser.plugins.models import RawDataSourceUser
 
 
@@ -65,6 +65,7 @@ class DataSourceUserSyncer:
         self.raw_users = raw_users
         self.overwrite = overwrite
         self.incremental = incremental
+        self.transformer = UsernameTransformer.load(data_source.id)
         self.converter = DataSourceUserConverter(data_source, ctx.logger)
         # 由于在部分老版本迁移过来的数据源中租户用户 ID 会由 username + 规则 拼接生成，
         # 该类数据源同步时候不可更新 username，而全新数据源对应租户 ID 都是 uuid 则不受影响
@@ -81,8 +82,7 @@ class DataSourceUserSyncer:
             return
 
         code_username_map = {
-            user.code: DataSourceUsernameHandler.generate(self.data_source, user.properties["username"])
-            for user in self.raw_users
+            user.code: self.transformer.to_stored(user.properties["username"]) for user in self.raw_users
         }
 
         # 查询同租户下其他数据源中已存在的冲突用户名

--- a/src/bk-user/bkuser/biz/data_source.py
+++ b/src/bk-user/bkuser/biz/data_source.py
@@ -15,9 +15,6 @@
 # We undertake not to change the open source license (MIT license) applicable
 # to the current version of the project delivered to anyone in the future.
 
-from typing import List
-
-from bkuser.apps.data_source.constants import DataSourceTypeEnum, DataSourceUsernameGenerateRule
 from bkuser.apps.data_source.models import (
     DataSource,
     DataSourceDepartment,
@@ -35,49 +32,6 @@ from bkuser.apps.tenant.models import (
     TenantUserIDGenerateConfig,
     TenantUserIDRecord,
 )
-
-
-class DataSourceUsernameHandler:
-    @staticmethod
-    def generate(data_source: DataSource, username: str) -> str:
-        """根据配置生成最终用户名"""
-        cfg = data_source.username_generate_config
-        if cfg.rule == DataSourceUsernameGenerateRule.ADD_AFFIX:
-            return f"{cfg.prefix}{username}{cfg.suffix}"
-        return username
-
-    @staticmethod
-    def parse(data_source: DataSource, username: str) -> str:
-        """根据配置解析出原始用户名"""
-        cfg = data_source.username_generate_config
-        if cfg.rule == DataSourceUsernameGenerateRule.ADD_AFFIX:
-            if cfg.prefix and username.startswith(cfg.prefix):
-                username = username[len(cfg.prefix) :]
-            if cfg.suffix and username.endswith(cfg.suffix):
-                username = username[: -len(cfg.suffix)]
-        return username
-
-    @staticmethod
-    def is_username_affix_exists(tenant_id: str, prefix: str, suffix: str, exclude_id: int | None = None) -> bool:
-        """校验同租户下 ADD_AFFIX 策略的用户名前后缀唯一性"""
-        qs = DataSource.objects.filter(owner_tenant_id=tenant_id, type=DataSourceTypeEnum.REAL)
-        if exclude_id:
-            qs = qs.exclude(id=exclude_id)
-
-        return qs.filter(
-            username_generate_config__rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
-            username_generate_config__prefix=prefix,
-            username_generate_config__suffix=suffix,
-        ).exists()
-
-    @staticmethod
-    def is_username_exists(
-        data_source_ids: List[int], username: str, excluded_data_source_user_id: int | None = None
-    ) -> bool:
-        queryset = DataSourceUser.objects.filter(data_source_id__in=data_source_ids, username=username)
-        if excluded_data_source_user_id:
-            queryset = queryset.exclude(id=excluded_data_source_user_id)
-        return queryset.exists()
 
 
 class DataSourceHandler:

--- a/src/bk-user/bkuser/biz/exporters.py
+++ b/src/bk-user/bkuser/biz/exporters.py
@@ -33,9 +33,9 @@ from bkuser.apps.data_source.models import (
     DataSourceUser,
     DataSourceUserLeaderRelation,
 )
+from bkuser.apps.data_source.transform import UsernameTransformer
 from bkuser.apps.tenant.constants import UserFieldDataType
 from bkuser.apps.tenant.models import TenantUserCustomField
-from bkuser.biz.data_source import DataSourceUsernameHandler
 
 
 class UserExcelWriter:
@@ -56,13 +56,13 @@ class UserExcelWriter:
         self.sheet: Worksheet = self.workbook["users"]
         self.sheet.alignment = Alignment(wrapText=True)
 
-        # 基础列数（用户名, 姓名, 邮箱, 手机, 组织, 上级）
+        # 基础列数（用户名，姓名，邮箱，手机，组织，上级）
         self.base_col_count = 6
         self._init_sheet_structure()
 
     def add_row(self, base_info: List[str], extras: Dict[str, Any]):
         # Q: 为什么不能这样写 extras.get(field.name) or ""
-        # A: 这会导致部分类型的零值被转为空字符串，不符合预期，比如 类型是NUMBER, 0 应该是 "0"，而非 ""
+        # A: 这会导致部分类型的零值被转为空字符串，不符合预期，比如 类型是 NUMBER, 0 应该是 "0"，而非 ""
         extra_values = [
             self._transform_custom_field_value(field, extras.get(field.name, "")) for field in self.custom_fields
         ]
@@ -85,7 +85,7 @@ class UserExcelWriter:
             if field.required:
                 name_cell.font = Font(color=colors.COLOR_INDEX[2])
 
-            # 设置提示信息(字段名的上一行）
+            # 设置提示信息 (字段名的上一行）
             tip_cell = self.sheet.cell(row=self.TIP_ROW_IDX, column=col_idx)
             tip_cell.value = self._get_field_tip(field)
             # 设置吸底 + 自动换行
@@ -102,7 +102,7 @@ class UserExcelWriter:
         """
         转换自定义字段的值，以字符串输出；注意枚举做 id 与 value 的映射输出处理
         """
-        # 对于单枚举（""）、多枚举（[]）、字符串("") 类型，当其为零值时，可提前返回空字符串
+        # 对于单枚举（""）、多枚举（[]）、字符串 ("") 类型，当其为零值时，可提前返回空字符串
         # 对于数值（0）类型，则需要按照正常处理，即 str(0)，不能返回空字符串
         # Note: 无值，value 本身就是空字符串
         if field.data_type != UserFieldDataType.NUMBER and not value:
@@ -154,7 +154,7 @@ def get_user_export_template(tenant_id: str) -> Workbook:
         "张三",
         "zhangsan@qq.com",
         "+8613512345678",
-        "公司/部门A,公司/部门B",
+        "公司/部门 A，公司/部门 B",
         "lisi,wangwu",
     ]
 
@@ -167,6 +167,7 @@ class DataSourceUserExporter:
 
     def __init__(self, data_source: DataSource):
         self.data_source = data_source
+        self.transformer = UsernameTransformer.load(data_source.id)
         self.users = DataSourceUser.objects.filter(data_source=data_source)
         self.custom_fields = TenantUserCustomField.objects.filter(tenant_id=data_source.owner_tenant_id)
         self.writer = UserExcelWriter(self.custom_fields)
@@ -181,12 +182,12 @@ class DataSourceUserExporter:
             phone = f"+{u.phone_country_code}{u.phone}" if u.phone else ""
             departments = ",".join(dept_org_map.get(dept_id, "") for dept_id in user_departments_map.get(u.id, []))
             leaders = ",".join(
-                DataSourceUsernameHandler.parse(self.data_source, user_username_map.get(leader_id, ""))
+                self.transformer.to_raw(user_username_map.get(leader_id, ""))
                 for leader_id in user_leaders_map.get(u.id, [])
             )
 
             base_info = [
-                DataSourceUsernameHandler.parse(self.data_source, u.username),
+                self.transformer.to_raw(u.username),
                 u.full_name,
                 u.email,
                 phone,

--- a/src/bk-user/bkuser/biz/tenant/tenant_creator.py
+++ b/src/bk-user/bkuser/biz/tenant/tenant_creator.py
@@ -26,7 +26,6 @@ from bkuser.apps.data_source.constants import DataSourceTypeEnum
 from bkuser.apps.data_source.models import (
     DataSource,
     DataSourceUser,
-    DataSourceUsernameGenerateConfig,
     LocalDataSourceIdentityInfo,
 )
 from bkuser.apps.idp.models import Idp
@@ -164,7 +163,6 @@ class TenantCreator:
                 "plugin_config": plugin_config,
             },
         )
-        DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
         return ds
 
     @staticmethod
@@ -178,7 +176,6 @@ class TenantCreator:
                 "plugin_config": LocalDataSourcePluginConfig(enable_password=False),
             },
         )
-        DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
         return ds
 
     @staticmethod

--- a/src/bk-user/pyproject.toml
+++ b/src/bk-user/pyproject.toml
@@ -182,8 +182,6 @@ layers = [
 ]
 ignore_imports = [
     "bkuser.apps.tenant.management.commands.* -> bkuser.biz.tenant",
-    "bkuser.apps.sync.converters -> bkuser.biz.data_source",
-    "bkuser.apps.sync.syncers.data_source_user -> bkuser.biz.data_source",
 ]
 
 # apps 分层

--- a/src/bk-user/tests/apis/web/data_source/conftest.py
+++ b/src/bk-user/tests/apis/web/data_source/conftest.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List
 
 import pytest
 from bkuser.apps.data_source.constants import DataSourceTypeEnum
-from bkuser.apps.data_source.models import DataSource, DataSourcePlugin, DataSourceUsernameGenerateConfig
+from bkuser.apps.data_source.models import DataSource, DataSourcePlugin
 from bkuser.apps.idp.constants import IdpStatus
 from bkuser.apps.idp.data_models import gen_data_source_match_rule_of_local
 from bkuser.apps.idp.models import Idp, IdpDataSourceRelation
@@ -51,7 +51,6 @@ def data_source(random_tenant, local_ds_plugin_cfg) -> DataSource:
             "plugin_config": LocalDataSourcePluginConfig(**local_ds_plugin_cfg),
         },
     )
-    DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
     return ds
 
 
@@ -151,15 +150,13 @@ def data_source_sync_tasks(data_source) -> List[DataSourceSyncTask]:
 def general_data_source(random_tenant, general_ds_plugin_cfg) -> DataSource:
     """General HTTP data source in the same tenant for batch-delete tests"""
     plugin = DataSourcePlugin.objects.get(id=DataSourcePluginEnum.GENERAL)
-    ds = DataSource.objects.create(
+    return DataSource.objects.create(
         owner_tenant_id=random_tenant.id,
         type=DataSourceTypeEnum.REAL,
         plugin=plugin,
         plugin_config=GeneralDataSourcePluginConfig(**general_ds_plugin_cfg),
         sync_config={"sync_period": 60},
     )
-    DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
-    return ds
 
 
 @pytest.fixture

--- a/src/bk-user/tests/apps/sync/syncers/test_data_source_user.py
+++ b/src/bk-user/tests/apps/sync/syncers/test_data_source_user.py
@@ -25,6 +25,7 @@ from bkuser.apps.data_source.models import (
     DataSourceDepartmentUserRelation,
     DataSourceUser,
     DataSourceUserLeaderRelation,
+    DataSourceUsernameGenerateConfig,
 )
 from bkuser.apps.sync.contexts import DataSourceSyncTaskContext
 from bkuser.apps.sync.syncers import (
@@ -383,11 +384,12 @@ class TestSyncDataSourceUser:
     def test_filter_conflict_users_with_username_config(
         self, data_source_sync_task_ctx, bare_local_data_source, local_ds_plugin, local_ds_plugin_cfg
     ):
-        cfg = bare_local_data_source.username_generate_config
-        cfg.rule = DataSourceUsernameGenerateRule.ADD_AFFIX
-        cfg.prefix = "ds1_"
-        cfg.suffix = ""
-        cfg.save(update_fields=["rule", "prefix", "suffix", "updated_at"])
+        DataSourceUsernameGenerateConfig.objects.create(
+            data_source=bare_local_data_source,
+            rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
+            prefix="ds1_",
+            suffix="",
+        )
 
         other_ds = DataSource.objects.create(
             owner_tenant_id=bare_local_data_source.owner_tenant_id,

--- a/src/bk-user/tests/biz/test_data_source.py
+++ b/src/bk-user/tests/biz/test_data_source.py
@@ -16,53 +16,38 @@
 # to the current version of the project delivered to anyone in the future.
 
 import pytest
-from bkuser.apps.data_source.constants import DataSourceUsernameGenerateRule
-from bkuser.apps.data_source.models import DataSourceUser
-from bkuser.biz.data_source import DataSourceUsernameHandler
+from bkuser.apps.data_source.models import DataSourceUsernameGenerateConfig
+from bkuser.apps.data_source.transform import UsernameTransformer
 
 pytestmark = pytest.mark.django_db
 
 
-def update_username_generate_config(data_source, *, rule, prefix="", suffix=""):
-    cfg = data_source.username_generate_config
-    cfg.rule = rule
-    cfg.prefix = prefix
-    cfg.suffix = suffix
-    cfg.save(update_fields=["rule", "prefix", "suffix", "updated_at"])
+class TestUsernameTransformer:
+    """测试 UsernameTransformer"""
 
+    def test_encode_identity(self):
+        transform = UsernameTransformer()
+        assert transform.to_stored("zhangsan") == "zhangsan"
 
-class TestDataSourceUsernameHandler:
-    """测试 DataSourceUsernameHandler"""
+    def test_encode_with_prefix(self):
+        transform = UsernameTransformer(prefix="corp_")
+        assert transform.to_stored("zhangsan") == "corp_zhangsan"
 
-    def test_generate_unchanged(self, bare_local_data_source):
-        assert DataSourceUsernameHandler.generate(bare_local_data_source, "zhangsan") == "zhangsan"
+    def test_encode_with_suffix(self):
+        transform = UsernameTransformer(suffix="_ext")
+        assert transform.to_stored("zhangsan") == "zhangsan_ext"
 
-    def test_generate_add_affix(self, bare_local_data_source):
-        update_username_generate_config(
-            bare_local_data_source,
-            rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
-            prefix="corp_",
-        )
-        assert DataSourceUsernameHandler.generate(bare_local_data_source, "zhangsan") == "corp_zhangsan"
+    def test_decode_identity(self):
+        transform = UsernameTransformer()
+        assert transform.to_raw("zhangsan") == "zhangsan"
 
-        update_username_generate_config(
-            bare_local_data_source,
-            rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
-            suffix="_ext",
-        )
-        assert DataSourceUsernameHandler.generate(bare_local_data_source, "zhangsan") == "zhangsan_ext"
+    def test_decode_strip_prefix(self):
+        transform = UsernameTransformer(prefix="corp_")
+        assert transform.to_raw("corp_zhangsan") == "zhangsan"
 
-    def test_parse_unchanged(self, bare_local_data_source):
-        assert DataSourceUsernameHandler.parse(bare_local_data_source, "zhangsan") == "zhangsan"
-
-    def test_parse_strip_prefix(self, bare_local_data_source):
-        update_username_generate_config(
-            bare_local_data_source,
-            rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
-            prefix="corp_",
-        )
-
-        assert DataSourceUsernameHandler.parse(bare_local_data_source, "corp_zhangsan") == "zhangsan"
+    def test_decode_strip_suffix(self):
+        transform = UsernameTransformer(suffix="_ext")
+        assert transform.to_raw("zhangsan_ext") == "zhangsan"
 
     @pytest.mark.parametrize(
         ("prefix", "suffix"),
@@ -72,67 +57,22 @@ class TestDataSourceUsernameHandler:
             ("", "_ext"),
         ],
     )
-    def test_generate_and_parse_round_trip(self, bare_local_data_source, prefix, suffix):
-        """generate 和 parse 互逆"""
-        rule = (
-            DataSourceUsernameGenerateRule.ADD_AFFIX
-            if (prefix or suffix)
-            else DataSourceUsernameGenerateRule.UNCHANGED
-        )
-        update_username_generate_config(
-            bare_local_data_source,
-            rule=rule,
-            prefix=prefix,
-            suffix=suffix,
-        )
-
+    def test_encode_decode_round_trip(self, prefix, suffix):
+        transform = UsernameTransformer(prefix=prefix, suffix=suffix)
         original = "zhangsan"
-        generated = DataSourceUsernameHandler.generate(bare_local_data_source, original)
-        parsed = DataSourceUsernameHandler.parse(bare_local_data_source, generated)
-        assert parsed == original
+        assert transform.to_raw(transform.to_stored(original)) == original
 
-    def test_is_username_affix_exists_not_exists(self, bare_local_data_source):
-        assert not DataSourceUsernameHandler.is_username_affix_exists(
-            bare_local_data_source.owner_tenant_id,
-            "corp_",
-            "",
-        )
+    def test_load_no_config(self, bare_local_data_source):
+        transform = UsernameTransformer.load(bare_local_data_source.id)
+        assert transform.unchanged
+        assert transform.to_stored("zhangsan") == "zhangsan"
 
-    def test_is_username_affix_exists_exists(self, bare_local_data_source):
-        update_username_generate_config(
-            bare_local_data_source,
-            rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
-            prefix="corp_",
-        )
-
-        assert DataSourceUsernameHandler.is_username_affix_exists(
-            bare_local_data_source.owner_tenant_id,
-            "corp_",
-            "",
-        )
-
-    def test_is_username_affix_exists_different_affix_not_match(self, bare_local_data_source):
-        update_username_generate_config(
-            bare_local_data_source,
-            rule=DataSourceUsernameGenerateRule.ADD_AFFIX,
-            prefix="corp_",
-        )
-
-        assert not DataSourceUsernameHandler.is_username_affix_exists(
-            bare_local_data_source.owner_tenant_id,
-            "other_",
-            "",
-        )
-
-    def test_is_username_exists_not_exists(self, bare_local_data_source):
-        assert not DataSourceUsernameHandler.is_username_exists([bare_local_data_source.id], "nonexistent")
-
-    def test_is_username_exists_exists(self, bare_local_data_source):
-        DataSourceUser.objects.create(
+    def test_load_with_config(self, bare_local_data_source):
+        DataSourceUsernameGenerateConfig.objects.create(
             data_source=bare_local_data_source,
-            code="u1",
-            username="zhangsan",
-            full_name="张三",
+            rule="add_affix",
+            prefix="corp_",
         )
-
-        assert DataSourceUsernameHandler.is_username_exists([bare_local_data_source.id], "zhangsan")
+        transform = UsernameTransformer.load(bare_local_data_source.id)
+        assert not transform.unchanged
+        assert transform.to_stored("zhangsan") == "corp_zhangsan"

--- a/src/bk-user/tests/biz/test_tenant.py
+++ b/src/bk-user/tests/biz/test_tenant.py
@@ -17,7 +17,7 @@
 
 import pytest
 from bkuser.apps.data_source.constants import DataSourceTypeEnum
-from bkuser.apps.data_source.models import DataSource, DataSourceUsernameGenerateConfig, LocalDataSourceIdentityInfo
+from bkuser.apps.data_source.models import DataSource, LocalDataSourceIdentityInfo
 from bkuser.apps.idp.models import IdpDataSourceRelation
 from bkuser.apps.tenant.constants import TenantStatus
 from bkuser.apps.tenant.models import (
@@ -73,7 +73,6 @@ class TestTenantCreator:
 
         assert data_source.type == DataSourceTypeEnum.BUILTIN_MANAGEMENT
         assert data_source.owner_tenant_id == "test-tenant"
-        assert DataSourceUsernameGenerateConfig.objects.filter(data_source=data_source).exists()
 
     def test_create_complex_builtin_data_source(self):
         """测试创建复杂的内建管理数据源"""
@@ -83,7 +82,6 @@ class TestTenantCreator:
 
         assert data_source.type == DataSourceTypeEnum.BUILTIN_MANAGEMENT
         assert data_source.owner_tenant_id == "test-tenant"
-        assert DataSourceUsernameGenerateConfig.objects.filter(data_source=data_source).exists()
 
     def test_create_virtual_data_source(self):
         """测试创建虚拟数据源"""
@@ -91,7 +89,6 @@ class TestTenantCreator:
 
         assert data_source.type == DataSourceTypeEnum.VIRTUAL
         assert data_source.owner_tenant_id == "test-tenant"
-        assert DataSourceUsernameGenerateConfig.objects.filter(data_source=data_source).exists()
 
     def test_create_builtin_manager(self):
         """测试创建内置管理员"""

--- a/src/bk-user/tests/fixtures/data_source.py
+++ b/src/bk-user/tests/fixtures/data_source.py
@@ -19,7 +19,7 @@ from typing import Any, Dict
 
 import pytest
 from bkuser.apps.data_source.constants import DataSourceTypeEnum
-from bkuser.apps.data_source.models import DataSource, DataSourcePlugin, DataSourceUsernameGenerateConfig
+from bkuser.apps.data_source.models import DataSource, DataSourcePlugin
 from bkuser.plugins.constants import DataSourcePluginEnum
 from bkuser.plugins.general.models import GeneralDataSourcePluginConfig
 from bkuser.plugins.local.models import LocalDataSourcePluginConfig
@@ -139,27 +139,23 @@ def local_ds_plugin() -> DataSourcePlugin:
 @pytest.fixture
 def bare_local_data_source(random_tenant, local_ds_plugin_cfg, local_ds_plugin) -> DataSource:
     """裸本地数据源（没有用户，部门等数据）"""
-    ds = DataSource.objects.create(
+    return DataSource.objects.create(
         owner_tenant_id=random_tenant.id,
         type=DataSourceTypeEnum.REAL,
         plugin=local_ds_plugin,
         plugin_config=LocalDataSourcePluginConfig(**local_ds_plugin_cfg),
     )
-    DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
-    return ds
 
 
 @pytest.fixture
 def bare_virtual_data_source(random_tenant, local_ds_plugin_cfg, local_ds_plugin) -> DataSource:
     """裸虚拟数据源（没有用户数据）"""
-    ds = DataSource.objects.create(
+    return DataSource.objects.create(
         owner_tenant_id=random_tenant.id,
         type=DataSourceTypeEnum.VIRTUAL,
         plugin=local_ds_plugin,
         plugin_config=LocalDataSourcePluginConfig(**local_ds_plugin_cfg),
     )
-    DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
-    return ds
 
 
 @pytest.fixture
@@ -203,15 +199,13 @@ def general_ds_plugin() -> DataSourcePlugin:
 @pytest.fixture
 def bare_general_data_source(random_tenant, general_ds_plugin_cfg, general_ds_plugin) -> DataSource:
     """裸通用 HTTP 数据源（没有用户，部门等数据）"""
-    ds = DataSource.objects.create(
+    return DataSource.objects.create(
         owner_tenant_id=random_tenant.id,
         type=DataSourceTypeEnum.REAL,
         plugin=general_ds_plugin,
         plugin_config=GeneralDataSourcePluginConfig(**general_ds_plugin_cfg),
         sync_config={"sync_period": 60},
     )
-    DataSourceUsernameGenerateConfig.objects.get_or_create(data_source=ds)
-    return ds
 
 
 @pytest.fixture


### PR DESCRIPTION
Replace DataSourceUsernameHandler with UsernameTransformer, create DataSourceUsernameGenerateConfig only for ADD_AFFIX, and keep serializer validation / view storage transform responsibilities separate.

### Description

Fixes # (issue)

### Checklist

- [ ] 填写 PR 描述及相关 issue (write PR description and related issue)
- [ ] 代码风格检查通过 (code style check passed)
- [ ] PR 中包含单元测试 (include unit test)
- [ ] 单元测试通过 (unit test passed)
- [ ] 本地开发联调环境验证通过 (local development environment verification passed)
